### PR TITLE
Split message structs into JSON and RPC structs.

### DIFF
--- a/go/tricorder/messages/api.go
+++ b/go/tricorder/messages/api.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"github.com/Symantec/tricorder/go/tricorder/types"
 	"github.com/Symantec/tricorder/go/tricorder/units"
+	"time"
 )
 
 var (
@@ -13,6 +14,19 @@ var (
 	// metric with given path exists.
 	ErrMetricNotFound = errors.New("messages: No metric found.")
 )
+
+// RpcRangeWithCount represents the number of values within a
+// particular range for go rpc
+type RpcRangeWithCount struct {
+	// Represents the lower bound of the range inclusive.
+	// Ignore for the lowest range which never has a lower bound.
+	Lower float64
+	// Represents the upper bound of the range exclusive.
+	// Ignore for the highest range which never has a upper bound.
+	Upper float64
+	// The number of values falling within the range.
+	Count uint64
+}
 
 // RangeWithCount represents the number of values within a particular range
 type RangeWithCount struct {
@@ -24,6 +38,22 @@ type RangeWithCount struct {
 	Upper *float64 `json:"upper,omitempty"`
 	// The number of values falling within the range.
 	Count uint64 `json:"count"`
+}
+
+// RpcDistribution represents a distribution of values for go rpc.
+type RpcDistribution struct {
+	// The minimum value
+	Min float64
+	// The maximum value
+	Max float64
+	// The average value
+	Average float64
+	// The approximate median value
+	Median float64
+	// The total number of values
+	Count uint64
+	// The number of values within each range
+	Ranges []*RpcRangeWithCount
 }
 
 // Distribution represents a distribution of values.
@@ -40,6 +70,58 @@ type Distribution struct {
 	Count uint64 `json:"count"`
 	// The number of values within each range
 	Ranges []*RangeWithCount `json:"ranges,omitempty"`
+}
+
+// Duration represents a duration of time
+// For negative durations, both Seconds and Nanoseconds are negative.
+type Duration struct {
+	Seconds     int64
+	Nanoseconds int32
+}
+
+func NewDuration(d time.Duration) Duration {
+	return newDuration(d)
+}
+
+// SinceEpoch returns the amount of time since unix epoch
+func SinceEpoch(t time.Time) Duration {
+	return sinceEpoch(t)
+}
+
+// AsGoDuration converts this duration to a go duration
+func (d Duration) AsGoDuration() time.Duration {
+	return d.asGoDuration()
+}
+
+// AsGoTime Converts this duration to a go time.
+// This is the inverse of SinceEpoch.
+func (d Duration) AsGoTime() time.Time {
+	return d.asGoTime()
+}
+
+func (d Duration) String() string {
+	return d._string()
+}
+
+// RpcValue represents the value of a metric for go rpc.
+type RpcValue struct {
+	// The value's type
+	Kind types.Type
+	// bool values stored here
+	BoolValue bool
+	// int values stored here
+	IntValue int64
+	// uint values stored here
+	UintValue uint64
+	// float values stored here
+	FloatValue float64
+	// string values are stored here.
+	StringValue string
+	// duration values stored here. Also time values are stored here
+	// as time since Jan 1, 1970 GMT.
+	DurationValue Duration
+	// Distributions stored here
+	DistributionValue *RpcDistribution
 }
 
 // Value represents the value of a metric.
@@ -62,6 +144,18 @@ type Value struct {
 	DistributionValue *Distribution `json:"distributionValue,omitempty"`
 }
 
+// RpcMetric represents a single metric for go rpc
+type RpcMetric struct {
+	// The absolute path to this metric
+	Path string
+	// The description of this metric
+	Description string
+	// The unit of measurement this metric represents
+	Unit units.Unit
+	// The value of this metric
+	Value *RpcValue
+}
+
 // Metric represents a single metric
 type Metric struct {
 	// The absolute path to this metric
@@ -73,6 +167,9 @@ type Metric struct {
 	// The value of this metric
 	Value *Value `json:"value"`
 }
+
+// RpcMetricList represents a list of rpc metrics.
+type RpcMetricList []*RpcMetric
 
 // MetricList represents a list of metrics.
 type MetricList []*Metric

--- a/go/tricorder/messages/duration.go
+++ b/go/tricorder/messages/duration.go
@@ -1,0 +1,39 @@
+package messages
+
+import (
+	"fmt"
+	"time"
+)
+
+func newDuration(d time.Duration) (result Duration) {
+	result.Seconds = int64(d / time.Second)
+	result.Nanoseconds = int32((d % time.Second) / time.Nanosecond)
+	return
+}
+
+// SinceEpoch returns the amount of time since unix epoch
+func sinceEpoch(t time.Time) (result Duration) {
+	result.Seconds = t.Unix()
+	result.Nanoseconds = int32(t.Nanosecond())
+	if result.Seconds < 0 && result.Nanoseconds > 0 {
+		result.Seconds++
+		result.Nanoseconds -= 1000000000 // 1 billion
+	}
+	return
+}
+
+func (d Duration) asGoDuration() time.Duration {
+	return time.Second*time.Duration(d.Seconds) + time.Duration(d.Nanoseconds)*time.Nanosecond
+}
+
+func (d Duration) asGoTime() time.Time {
+	return time.Unix(d.Seconds, int64(d.Nanoseconds))
+}
+
+func (d Duration) _string() string {
+	formattedNs := d.Nanoseconds
+	if formattedNs < 0 {
+		formattedNs = -formattedNs
+	}
+	return fmt.Sprintf("%d.%09d", d.Seconds, formattedNs)
+}

--- a/go/tricorder/metric_test.go
+++ b/go/tricorder/metric_test.go
@@ -408,7 +408,7 @@ func TestAPI(t *testing.T) {
 		&messages.Value{
 			Kind:        types.String,
 			StringValue: stringPtr("--help")},
-		argsMetric.AsRPCValue(nil))
+		argsMetric.AsJsonValue(nil))
 	assertValueEquals(t, "\"--help\"", argsMetric.AsHtmlString(nil))
 
 	// Check /testname
@@ -419,7 +419,7 @@ func TestAPI(t *testing.T) {
 		&messages.Value{
 			Kind:        types.String,
 			StringValue: stringPtr("My application")},
-		nameMetric.AsRPCValue(nil))
+		nameMetric.AsJsonValue(nil))
 	assertValueEquals(t, "\"My application\"", nameMetric.AsHtmlString(nil))
 
 	// Check /proc/temperature
@@ -430,7 +430,7 @@ func TestAPI(t *testing.T) {
 		&messages.Value{
 			Kind:       types.Float,
 			FloatValue: floatPtr(22.5)},
-		temperatureMetric.AsRPCValue(nil))
+		temperatureMetric.AsJsonValue(nil))
 	assertValueEquals(t, "22.5", temperatureMetric.AsHtmlString(nil))
 
 	// Check /proc/start-time
@@ -441,7 +441,7 @@ func TestAPI(t *testing.T) {
 		&messages.Value{
 			Kind:     types.Int,
 			IntValue: intPtr(-1234567)},
-		startTimeMetric.AsRPCValue(nil))
+		startTimeMetric.AsJsonValue(nil))
 	assertValueEquals(t, "-1234567", startTimeMetric.AsHtmlString(nil))
 
 	// Check /proc/some-time
@@ -452,7 +452,7 @@ func TestAPI(t *testing.T) {
 		&messages.Value{
 			Kind:        types.Time,
 			StringValue: stringPtr("1447594013.007265341")},
-		someTimeMetric.AsRPCValue(nil))
+		someTimeMetric.AsJsonValue(nil))
 	assertValueEquals(t, "2015-11-15T13:26:53.007265341Z", someTimeMetric.AsHtmlString(nil))
 
 	// Check /proc/some-time-ptr
@@ -464,7 +464,7 @@ func TestAPI(t *testing.T) {
 		&messages.Value{
 			Kind:        types.Time,
 			StringValue: stringPtr("0.000000000")},
-		someTimePtrMetric.AsRPCValue(nil))
+		someTimePtrMetric.AsJsonValue(nil))
 	assertValueEquals(t, "0001-01-01T00:00:00Z", someTimePtrMetric.AsHtmlString(nil))
 
 	newTime := time.Date(2015, time.September, 6, 5, 26, 35, 0, time.UTC)
@@ -474,7 +474,7 @@ func TestAPI(t *testing.T) {
 		&messages.Value{
 			Kind:        types.Time,
 			StringValue: stringPtr("1441517195.000000000")},
-		someTimePtrMetric.AsRPCValue(nil))
+		someTimePtrMetric.AsJsonValue(nil))
 	assertValueEquals(
 		t,
 		"2015-09-06T05:26:35Z",
@@ -488,7 +488,7 @@ func TestAPI(t *testing.T) {
 		&messages.Value{
 			Kind:      types.Uint,
 			UintValue: uintPtr(500)},
-		rpcCountMetric.AsRPCValue(nil))
+		rpcCountMetric.AsJsonValue(nil))
 	assertValueEquals(t, "500", rpcCountMetric.AsHtmlString(nil))
 
 	// check /proc/foo/bar/baz
@@ -499,7 +499,7 @@ func TestAPI(t *testing.T) {
 		&messages.Value{
 			Kind:       types.Float,
 			FloatValue: floatPtr(12.375)},
-		bazMetric.AsRPCValue(nil))
+		bazMetric.AsJsonValue(nil))
 	assertValueEquals(t, "12.375", bazMetric.AsHtmlString(nil))
 
 	// check /proc/foo/bar/abool
@@ -510,7 +510,7 @@ func TestAPI(t *testing.T) {
 		&messages.Value{
 			Kind:      types.Bool,
 			BoolValue: boolPtr(true)},
-		aboolMetric.AsRPCValue(nil))
+		aboolMetric.AsJsonValue(nil))
 	assertValueEquals(t, "true", aboolMetric.AsHtmlString(nil))
 
 	// check /proc/foo/bar/anotherBool
@@ -521,14 +521,14 @@ func TestAPI(t *testing.T) {
 		&messages.Value{
 			Kind:      types.Bool,
 			BoolValue: boolPtr(false)},
-		anotherBoolMetric.AsRPCValue(nil))
+		anotherBoolMetric.AsJsonValue(nil))
 	assertValueEquals(t, "false", anotherBoolMetric.AsHtmlString(nil))
 
 	// Check /proc/rpc-latency
 	rpcLatency := root.GetMetric("/proc/rpc-latency")
 	verifyMetric(t, "RPC latency", units.Millisecond, rpcLatency)
 
-	actual := rpcLatency.AsRPCValue(nil)
+	actual := rpcLatency.AsJsonValue(nil)
 
 	if actual.DistributionValue.Median < 249 || actual.DistributionValue.Median >= 250 {
 		t.Errorf("Median out of range: %f", actual.DistributionValue.Median)

--- a/go/tricorder/rpc.go
+++ b/go/tricorder/rpc.go
@@ -5,15 +5,15 @@ import (
 	"net/rpc"
 )
 
-func rpcAsMetric(m *metric, s *session) *messages.Metric {
-	return &messages.Metric{
+func rpcAsMetric(m *metric, s *session) *messages.RpcMetric {
+	return &messages.RpcMetric{
 		Path:        m.AbsPath(),
 		Description: m.Description,
 		Unit:        m.Unit,
-		Value:       m.AsRPCValue(s)}
+		Value:       m.AsRpcValue(s)}
 }
 
-type rpcMetricsCollector messages.MetricList
+type rpcMetricsCollector messages.RpcMetricList
 
 func (c *rpcMetricsCollector) Collect(m *metric, s *session) (err error) {
 	*c = append(*c, rpcAsMetric(m, s))
@@ -22,12 +22,12 @@ func (c *rpcMetricsCollector) Collect(m *metric, s *session) (err error) {
 
 type rpcType int
 
-func (t *rpcType) ListMetrics(path string, response *messages.MetricList) error {
+func (t *rpcType) ListMetrics(path string, response *messages.RpcMetricList) error {
 	return root.GetAllMetricsByPath(
 		path, (*rpcMetricsCollector)(response), nil)
 }
 
-func (t *rpcType) GetMetric(path string, response *messages.Metric) error {
+func (t *rpcType) GetMetric(path string, response *messages.RpcMetric) error {
 	m := root.GetMetric(path)
 	if m == nil {
 		return messages.ErrMetricNotFound

--- a/go/tricorderclient/tricorderclient.go
+++ b/go/tricorderclient/tricorderclient.go
@@ -29,7 +29,7 @@ func main() {
 		log.Fatal("dialing:", err)
 	}
 	defer client.Close()
-	var metrics messages.MetricList
+	var metrics messages.RpcMetricList
 	err = client.Call("MetricsServer.ListMetrics", "", &metrics)
 	if err != nil {
 		log.Fatal("Calling:", err)
@@ -42,7 +42,7 @@ func main() {
 	}
 	printAsJson("aaa/bbb metrics", metrics)
 
-	var single messages.Metric
+	var single messages.RpcMetric
 	err = client.Call("MetricsServer.GetMetric", "/proc/foo/bar/baz", &single)
 	if err != nil {
 		log.Fatal("Calling:", err)


### PR DESCRIPTION
Before I was using the same set of structs for both JSON and go RPC.
Since we will be encoding times and durations differently for RPC and
because of the way RPC handles pointers to zero values of primitive
types differently than JSON, its time to have two sets of structs.

I will need to add tests for the new RPC structs later, but I wanted to
get something out there for you to look at.
