### PR TITLE
Make the clients call rpc.RegisterHTTP().

### DIFF
--- a/go/tricorder/doc.go
+++ b/go/tricorder/doc.go
@@ -7,9 +7,12 @@ Use the tricorder package in your application like so:
 
 	import "github.com/Symantec/tricorder/go/tricorder"
 	import "net/http"
+	import "net/rpc"
 	func main() {
 		doYourInitialization();
 		registerYourOwnHttpHandlers();
+		// Needed to support Go RPC. Client must call.
+		rpc.HandleHTTP()
 		if err := http.ListenAndServe(":8080", http.DefaultServeMux); err != nil {
 			fmt.Println(err)
 		}

--- a/go/tricorder/rpc.go
+++ b/go/tricorder/rpc.go
@@ -38,5 +38,4 @@ func (t *rpcType) GetMetric(path string, response *messages.RpcMetric) error {
 
 func initRpcHandlers() {
 	rpc.RegisterName("MetricsServer", new(rpcType))
-	rpc.HandleHTTP()
 }

--- a/go/tricorderdemo/tricorderdemo.go
+++ b/go/tricorderdemo/tricorderdemo.go
@@ -8,6 +8,7 @@ import (
 	"github.com/keep94/weblogs"
 	"log"
 	"net/http"
+	"net/rpc"
 )
 
 func registerMetrics() {
@@ -77,6 +78,7 @@ func rpcCountCallback() uint64 {
 
 func main() {
 	registerMetrics()
+	rpc.HandleHTTP()
 	defaultHandler := context.ClearHandler(
 		weblogs.HandlerWithOptions(
 			http.DefaultServeMux,


### PR DESCRIPTION
Don't call this within the library because a second call to it panics.
