### PR TITLE
Make durations that aren't distribution unit aware.

### DIFF
--- a/go/tricorder/messages/api.go
+++ b/go/tricorder/messages/api.go
@@ -103,8 +103,15 @@ func (d Duration) AsGoTime() time.Time {
 	return d.asGoTime()
 }
 
+// String shows in seconds
 func (d Duration) String() string {
-	return d._string()
+	return d.stringUsingUnits(units.Second)
+}
+
+// StringUsingUnits shows in specified time unit.
+// If unit not a time, shows in seconds.
+func (d Duration) StringUsingUnits(unit units.Unit) string {
+	return d.stringUsingUnits(unit)
 }
 
 // RpcValue represents the value of a metric for go rpc.

--- a/go/tricorder/messages/duration.go
+++ b/go/tricorder/messages/duration.go
@@ -2,7 +2,12 @@ package messages
 
 import (
 	"fmt"
+	"github.com/Symantec/tricorder/go/tricorder/units"
 	"time"
+)
+
+const (
+	oneMillion = 1000000
 )
 
 func newDuration(d time.Duration) (result Duration) {
@@ -34,10 +39,20 @@ func (d Duration) asGoTime() time.Time {
 	return time.Unix(d.Seconds, int64(d.Nanoseconds))
 }
 
-func (d Duration) _string() string {
+func (d Duration) stringUsingUnits(unit units.Unit) string {
 	formattedNs := d.Nanoseconds
 	if formattedNs < 0 {
 		formattedNs = -formattedNs
 	}
-	return fmt.Sprintf("%d.%09d", d.Seconds, formattedNs)
+	switch unit {
+	case units.Millisecond:
+		return fmt.Sprintf(
+			"%d%03d.%06d",
+			d.Seconds,
+			formattedNs/oneMillion,
+			formattedNs%oneMillion)
+	default: // second
+		return fmt.Sprintf("%d.%09d", d.Seconds, formattedNs)
+	}
+
 }

--- a/go/tricorder/messages/duration_test.go
+++ b/go/tricorder/messages/duration_test.go
@@ -2,6 +2,7 @@ package messages_test
 
 import (
 	"github.com/Symantec/tricorder/go/tricorder/messages"
+	"github.com/Symantec/tricorder/go/tricorder/units"
 	"testing"
 	"time"
 )
@@ -136,5 +137,23 @@ func TestTime(t *testing.T) {
 	}
 	if out := expected.AsGoTime().UTC(); out != tm {
 		t.Errorf("Expected %d, got %d", tm, out)
+	}
+}
+
+func TestString(t *testing.T) {
+	dur := messages.Duration{Seconds: 57}
+	if out := dur.String(); out != "57.000000000" {
+		t.Errorf("Expected 57.000000000, got %s", out)
+	}
+	dur = messages.Duration{Seconds: -53, Nanoseconds: -200000000}
+	if out := dur.String(); out != "-53.200000000" {
+		t.Errorf("Expected -53.200000000, got %s", out)
+	}
+	if out := dur.StringUsingUnits(units.Millisecond); out != "-53200.000000" {
+		t.Errorf("Expected -53200.000000, got %s", out)
+	}
+	dur = messages.Duration{Seconds: 53, Nanoseconds: 123456789}
+	if out := dur.StringUsingUnits(units.Millisecond); out != "53123.456789" {
+		t.Errorf("Expected 53123.456789, got %s", out)
 	}
 }


### PR DESCRIPTION
For distributions, we take care to covert Durations, which are time
unit aware, to the metric's unit. We should do the same for metrics
that are not distributions.
