### PR TITLE
large numbers in compact form and readable durations  in html.

### DIFF
--- a/go/tricorder/messages/api.go
+++ b/go/tricorder/messages/api.go
@@ -114,6 +114,17 @@ func (d Duration) StringUsingUnits(unit units.Unit) string {
 	return d.stringUsingUnits(unit)
 }
 
+// IsNegative returns true if this duration is negative.
+func (d Duration) IsNegative() bool {
+	return d.isNegative()
+}
+
+// PrettyFormat pretty formats this duration.
+// PrettyFormat panics if this duration is negative.
+func (d Duration) PrettyFormat() string {
+	return d.prettyFormat()
+}
+
 // RpcValue represents the value of a metric for go rpc.
 type RpcValue struct {
 	// The value's type

--- a/go/tricorder/messages/duration.go
+++ b/go/tricorder/messages/duration.go
@@ -52,3 +52,43 @@ func (d Duration) stringUsingUnits(unit units.Unit) string {
 	}
 
 }
+
+func (d Duration) isNegative() bool {
+	return d.Nanoseconds < 0 || d.Seconds < 0
+}
+
+func (d Duration) prettyFormat() string {
+	if d.isNegative() {
+		panic("Cannot pretty format negative durations")
+	}
+	switch {
+	case d.Seconds == 0 && d.Nanoseconds < 10000:
+		return fmt.Sprintf("%dns", d.Nanoseconds)
+	case d.Seconds == 0 && d.Nanoseconds < 10000000:
+		return fmt.Sprintf("%dμs", d.Nanoseconds/1000)
+	case d.Seconds == 0:
+		return fmt.Sprintf("%dms", d.Nanoseconds/1000000)
+	case d.Seconds < 60:
+		return fmt.Sprintf("%d.%03ds", d.Seconds, d.Nanoseconds/1000000)
+	case d.Seconds < 60*60:
+		return fmt.Sprintf(
+			"%dm %d.%03ds",
+			d.Seconds/60,
+			d.Seconds%60,
+			d.Nanoseconds/1000000)
+	case d.Seconds < 24*60*60:
+		return fmt.Sprintf(
+			"%dh %dm %ds",
+			d.Seconds/(60*60),
+			(d.Seconds%(60*60))/60,
+			d.Seconds%60)
+	default:
+		return fmt.Sprintf(
+			"%dd %dh %dm %ds",
+			d.Seconds/(24*60*60),
+			(d.Seconds%(24*60*60))/(60*60),
+			(d.Seconds%(60*60))/60,
+			d.Seconds%60)
+
+	}
+}

--- a/go/tricorder/messages/duration_test.go
+++ b/go/tricorder/messages/duration_test.go
@@ -9,6 +9,9 @@ import (
 
 func TestDuration(t *testing.T) {
 	var expected messages.Duration
+	if expected.IsNegative() {
+		t.Error("Expected duration to be positive.")
+	}
 	var duration time.Duration
 	actual := messages.NewDuration(duration)
 	if expected != actual {
@@ -27,6 +30,9 @@ func TestDuration(t *testing.T) {
 		t.Errorf("Expected %d, got %d", duration, out)
 	}
 	expected = messages.Duration{Seconds: 1, Nanoseconds: 0}
+	if expected.IsNegative() {
+		t.Error("Expected duration to be positive.")
+	}
 	duration = time.Second
 	actual = messages.NewDuration(duration)
 	if expected != actual {
@@ -45,6 +51,9 @@ func TestDuration(t *testing.T) {
 		t.Errorf("Expected %d, got %d", duration, out)
 	}
 	expected = messages.Duration{Seconds: 0, Nanoseconds: -1}
+	if !expected.IsNegative() {
+		t.Error("Expected duration to be negative.")
+	}
 	duration = -time.Nanosecond
 	actual = messages.NewDuration(duration)
 	if expected != actual {
@@ -54,6 +63,9 @@ func TestDuration(t *testing.T) {
 		t.Errorf("Expected %d, got %d", duration, out)
 	}
 	expected = messages.Duration{Seconds: -1, Nanoseconds: 0}
+	if !expected.IsNegative() {
+		t.Error("Expected duration to be negative.")
+	}
 	duration = -time.Second
 	actual = messages.NewDuration(duration)
 	if expected != actual {
@@ -155,5 +167,50 @@ func TestString(t *testing.T) {
 	dur = messages.Duration{Seconds: 53, Nanoseconds: 123456789}
 	if out := dur.StringUsingUnits(units.Millisecond); out != "53123.456789" {
 		t.Errorf("Expected 53123.456789, got %s", out)
+	}
+}
+
+func TestPrettyFormat(t *testing.T) {
+	var dur messages.Duration
+	assertStringEquals(t, "0ns", dur.PrettyFormat())
+	dur = messages.Duration{Nanoseconds: 7}
+	assertStringEquals(t, "7ns", dur.PrettyFormat())
+	dur = messages.Duration{Nanoseconds: 9999}
+	assertStringEquals(t, "9999ns", dur.PrettyFormat())
+	dur = messages.Duration{Nanoseconds: 10000}
+	assertStringEquals(t, "10μs", dur.PrettyFormat())
+	dur = messages.Duration{Nanoseconds: 13789}
+	assertStringEquals(t, "13μs", dur.PrettyFormat())
+	dur = messages.Duration{Nanoseconds: 9999999}
+	assertStringEquals(t, "9999μs", dur.PrettyFormat())
+	dur = messages.Duration{Nanoseconds: 10000000}
+	assertStringEquals(t, "10ms", dur.PrettyFormat())
+	dur = messages.Duration{Nanoseconds: 678000000}
+	assertStringEquals(t, "678ms", dur.PrettyFormat())
+	dur = messages.Duration{Nanoseconds: 999000000}
+	assertStringEquals(t, "999ms", dur.PrettyFormat())
+	dur = messages.Duration{Seconds: 1}
+	assertStringEquals(t, "1.000s", dur.PrettyFormat())
+	dur = messages.Duration{Seconds: 35, Nanoseconds: 871000000}
+	assertStringEquals(t, "35.871s", dur.PrettyFormat())
+	dur = messages.Duration{Seconds: 59, Nanoseconds: 999000000}
+	assertStringEquals(t, "59.999s", dur.PrettyFormat())
+	dur = messages.Duration{Seconds: 60}
+	assertStringEquals(t, "1m 0.000s", dur.PrettyFormat())
+	dur = messages.Duration{Seconds: 3541, Nanoseconds: 10000000}
+	assertStringEquals(t, "59m 1.010s", dur.PrettyFormat())
+	dur = messages.Duration{Seconds: 3600}
+	assertStringEquals(t, "1h 0m 0s", dur.PrettyFormat())
+	dur = messages.Duration{Seconds: 83000}
+	assertStringEquals(t, "23h 3m 20s", dur.PrettyFormat())
+	dur = messages.Duration{Seconds: 86400}
+	assertStringEquals(t, "1d 0h 0m 0s", dur.PrettyFormat())
+	dur = messages.Duration{Seconds: 200000}
+	assertStringEquals(t, "2d 7h 33m 20s", dur.PrettyFormat())
+}
+
+func assertStringEquals(t *testing.T, expected, actual string) {
+	if expected != actual {
+		t.Errorf("Expected %s, got %s", expected, actual)
 	}
 }

--- a/go/tricorder/metric_test.go
+++ b/go/tricorder/metric_test.go
@@ -533,6 +533,8 @@ func TestAPI(t *testing.T) {
 			},
 		},
 		inSecondMetric.AsRpcValue(nil))
+	assertValueEquals(t, "-21.053000000", inSecondMetric.AsHtmlString(nil))
+	assertValueEquals(t, "-21.053000000", inSecondMetric.AsTextString(nil))
 
 	// Check /times/milliseconds
 	inMillisecondMetric := root.GetMetric("/times/milliseconds")
@@ -553,6 +555,8 @@ func TestAPI(t *testing.T) {
 			},
 		},
 		inMillisecondMetric.AsRpcValue(nil))
+	assertValueEquals(t, "7.008s", inMillisecondMetric.AsHtmlString(nil))
+	assertValueEquals(t, "7008.000000", inMillisecondMetric.AsTextString(nil))
 
 	// Check /proc/temperature
 	temperatureMetric := root.GetMetric("/proc/temperature")
@@ -590,7 +594,8 @@ func TestAPI(t *testing.T) {
 			Bits:     64,
 			IntValue: -1234567},
 		startTimeMetric.AsRpcValue(nil))
-	assertValueEquals(t, "-1234567", startTimeMetric.AsHtmlString(nil))
+	assertValueEquals(t, "-1234567", startTimeMetric.AsTextString(nil))
+	assertValueEquals(t, "-1.23 million", startTimeMetric.AsHtmlString(nil))
 
 	// Check /proc/some-time
 	someTimeMetric := root.GetMetric("/proc/some-time")
@@ -1004,6 +1009,49 @@ func TestMedianDataSkewedHigh(t *testing.T) {
 	if median-750.0 > 1.0 || median-750.0 < -1.0 {
 		t.Errorf("Median out of range: %f", median)
 	}
+}
+
+func TestCompactDecimalSigned(t *testing.T) {
+	suffixes := []string{" thou", " mil", " bil"}
+	assertValueEquals(t, "0", iCompactForm(0, 900, suffixes))
+	assertValueEquals(t, "93", iCompactForm(93, 900, suffixes))
+	assertValueEquals(t, "-93", iCompactForm(-93, 900, suffixes))
+	assertValueEquals(t, "899", iCompactForm(899, 900, suffixes))
+	assertValueEquals(t, "-899", iCompactForm(-899, 900, suffixes))
+	assertValueEquals(t, "1.00 thou", iCompactForm(900, 900, suffixes))
+	assertValueEquals(t, "-1.00 thou", iCompactForm(-900, 900, suffixes))
+	assertValueEquals(t, "1.01 thou", iCompactForm(905, 900, suffixes))
+	assertValueEquals(t, "-1.01 thou", iCompactForm(-905, 900, suffixes))
+	assertValueEquals(t, "9.99 thou", iCompactForm(8995, 900, suffixes))
+	assertValueEquals(t, "-9.99 thou", iCompactForm(-8995, 900, suffixes))
+	assertValueEquals(t, "10.0 thou", iCompactForm(8996, 900, suffixes))
+	assertValueEquals(t, "-10.0 thou", iCompactForm(-8996, 900, suffixes))
+	assertValueEquals(t, "11.1 thou", iCompactForm(10000, 900, suffixes))
+	assertValueEquals(t, "-11.1 thou", iCompactForm(-10000, 900, suffixes))
+	assertValueEquals(t, "99.9 thou", iCompactForm(89954, 900, suffixes))
+	assertValueEquals(t, "-99.9 thou", iCompactForm(-89954, 900, suffixes))
+	assertValueEquals(t, "100 thou", iCompactForm(89955, 900, suffixes))
+	assertValueEquals(t, "-100 thou", iCompactForm(-89955, 900, suffixes))
+	assertValueEquals(t, "900 thou", iCompactForm(809999, 900, suffixes))
+	assertValueEquals(t, "-900 thou", iCompactForm(-809999, 900, suffixes))
+	assertValueEquals(t, "1.00 mil", iCompactForm(810000, 900, suffixes))
+	assertValueEquals(t, "-1.00 mil", iCompactForm(-810000, 900, suffixes))
+}
+
+func TestCompactDecimalUnsigned(t *testing.T) {
+	suffixes := []string{" thou", " mil", " bil"}
+	assertValueEquals(t, "0", uCompactForm(0, 900, suffixes))
+	assertValueEquals(t, "93", uCompactForm(93, 900, suffixes))
+	assertValueEquals(t, "899", uCompactForm(899, 900, suffixes))
+	assertValueEquals(t, "1.00 thou", uCompactForm(900, 900, suffixes))
+	assertValueEquals(t, "1.01 thou", uCompactForm(905, 900, suffixes))
+	assertValueEquals(t, "9.99 thou", uCompactForm(8995, 900, suffixes))
+	assertValueEquals(t, "10.0 thou", uCompactForm(8996, 900, suffixes))
+	assertValueEquals(t, "11.1 thou", uCompactForm(10000, 900, suffixes))
+	assertValueEquals(t, "99.9 thou", uCompactForm(89954, 900, suffixes))
+	assertValueEquals(t, "100 thou", uCompactForm(89955, 900, suffixes))
+	assertValueEquals(t, "900 thou", uCompactForm(809999, 900, suffixes))
+	assertValueEquals(t, "1.00 mil", uCompactForm(810000, 900, suffixes))
 }
 
 func rpcCountCallback() uint {


### PR DESCRIPTION
For bytes, use 1024 radix instead of 1000 with appropriate suffixes.
