### PR TITLE
Remove Unit field from metric type.

### DIFF
--- a/go/tricorder/html.go
+++ b/go/tricorder/html.go
@@ -108,7 +108,7 @@ func (v *htmlView) IsDistribution() bool {
 }
 
 func (v *htmlView) HasUnit() bool {
-	return v.Metric.Unit != units.None
+	return v.Metric.Unit() != units.None
 }
 
 func (v *htmlView) Link(d *directory) string {

--- a/go/tricorder/json.go
+++ b/go/tricorder/json.go
@@ -15,7 +15,7 @@ func jsonAsMetric(m *metric, s *session) *messages.Metric {
 	return &messages.Metric{
 		Path:        m.AbsPath(),
 		Description: m.Description,
-		Unit:        m.Unit,
+		Unit:        m.Unit(),
 		Value:       m.AsJsonValue(s)}
 }
 

--- a/go/tricorder/metric.go
+++ b/go/tricorder/metric.go
@@ -477,6 +477,11 @@ func (v *value) Type() types.Type {
 	return v.valType
 }
 
+// Unit returns the unit of this value.
+func (v *value) Unit() units.Unit {
+	return v.unit
+}
+
 // Bits returns the size in bits if the type is an Int, Uint, for Float.
 // Otherwise Bits returns 0.
 func (v *value) Bits() int {
@@ -790,8 +795,6 @@ func (v *value) AsDistribution() *distribution {
 type metric struct {
 	// The description of the metric
 	Description string
-	// The unit of measurement
-	Unit units.Unit
 	// The value of the metric
 	*value
 	enclosingListEntry *listEntry
@@ -1035,7 +1038,6 @@ func (d *directory) registerMetric(
 	}
 	metric := &metric{
 		Description: description,
-		Unit:        unit,
 		value:       newValue(value, region, unit)}
 	return current.storeMetric(path.Base(), metric)
 }

--- a/go/tricorder/rpc.go
+++ b/go/tricorder/rpc.go
@@ -9,7 +9,7 @@ func rpcAsMetric(m *metric, s *session) *messages.RpcMetric {
 	return &messages.RpcMetric{
 		Path:        m.AbsPath(),
 		Description: m.Description,
-		Unit:        m.Unit,
+		Unit:        m.Unit(),
 		Value:       m.AsRpcValue(s)}
 }
 


### PR DESCRIPTION
the value field in the metric type already has a copy of the unit.
