### PR TITLE
Replace type specific value fields with a single type interface field.

### DIFF
--- a/go/tricorder/messages/api.go
+++ b/go/tricorder/messages/api.go
@@ -122,8 +122,10 @@ type Metric struct {
 type MetricList []*Metric
 
 func init() {
-	var dur Duration
+	var tm time.Time
+	var dur time.Duration
 	var dist *Distribution
+	gob.Register(tm)
 	gob.Register(dur)
 	gob.Register(dist)
 }

--- a/go/tricorder/messages/api.go
+++ b/go/tricorder/messages/api.go
@@ -1,8 +1,9 @@
 // Package messages provides the types needed to collect metrics via
-// the go rpc calls or the REST API mentioned in the tricorder package.
+// the go rpc calls and the REST API mentioned in the tricorder package.
 package messages
 
 import (
+	"encoding/gob"
 	"errors"
 	"github.com/Symantec/tricorder/go/tricorder/types"
 	"github.com/Symantec/tricorder/go/tricorder/units"
@@ -15,47 +16,17 @@ var (
 	ErrMetricNotFound = errors.New("messages: No metric found.")
 )
 
-// RpcRangeWithCount represents the number of values within a
-// particular range for go rpc
-type RpcRangeWithCount struct {
+// RangeWithCount represents the number of values within a
+// particular range.
+type RangeWithCount struct {
 	// Represents the lower bound of the range inclusive.
 	// Ignore for the lowest range which never has a lower bound.
-	Lower float64
+	Lower float64 `json:"lower"`
 	// Represents the upper bound of the range exclusive.
 	// Ignore for the highest range which never has a upper bound.
-	Upper float64
-	// The number of values falling within the range.
-	Count uint64
-}
-
-// RangeWithCount represents the number of values within a particular range
-type RangeWithCount struct {
-	// If non nil, represents the lower bound of the range inclusive.
-	// nil means no lower bound
-	Lower *float64 `json:"lower,omitempty"`
-	// If non nil, represents the upper bound of the range exclusive.
-	// nil means no upper bound
-	Upper *float64 `json:"upper,omitempty"`
+	Upper float64 `json:"upper"`
 	// The number of values falling within the range.
 	Count uint64 `json:"count"`
-}
-
-// RpcDistribution represents a distribution of values for go rpc.
-type RpcDistribution struct {
-	// The minimum value
-	Min float64
-	// The maximum value
-	Max float64
-	// The average value
-	Average float64
-	// The approximate median value
-	Median float64
-	// The sum
-	Sum float64
-	// The total number of values
-	Count uint64
-	// The number of values within each range
-	Ranges []*RpcRangeWithCount
 }
 
 // Distribution represents a distribution of values.
@@ -125,61 +96,14 @@ func (d Duration) PrettyFormat() string {
 	return d.prettyFormat()
 }
 
-// RpcValue represents the value of a metric for go rpc.
-type RpcValue struct {
-	// The value's type
-	Kind types.Type
-	// The value's size in bits if Int, Uint, or float
-	Bits int
-	// bool values stored here
-	BoolValue bool
-	// int values stored here
-	IntValue int64
-	// uint values stored here
-	UintValue uint64
-	// float values stored here
-	FloatValue float64
-	// string values are stored here.
-	StringValue string
-	// duration values stored here. Also time values are stored here
-	// as time since Jan 1, 1970 GMT.
-	DurationValue Duration
-	// Distributions stored here
-	DistributionValue *RpcDistribution
-}
-
 // Value represents the value of a metric.
 type Value struct {
 	// The value's type
 	Kind types.Type `json:"kind"`
 	// The value's size in bits if Int, Uint, or float
 	Bits int `json:"bits,omitempty"`
-	// bool values stored here
-	BoolValue *bool `json:"boolValue,omitempty"`
-	// int values stored here
-	IntValue *int64 `json:"intValue,omitempty"`
-	// uint values stored here
-	UintValue *uint64 `json:"uintValue,omitempty"`
-	// float values stored here
-	FloatValue *float64 `json:"floatValue,omitempty"`
-	// string values are stored here. Also time values are stored here
-	// as seconds after Jan 1, 1970 GMT in this format:
-	// 1234567890.987654321
-	StringValue *string `json:"stringValue,omitempty"`
-	// Distributions stored here
-	DistributionValue *Distribution `json:"distributionValue,omitempty"`
-}
-
-// RpcMetric represents a single metric for go rpc
-type RpcMetric struct {
-	// The absolute path to this metric
-	Path string
-	// The description of this metric
-	Description string
-	// The unit of measurement this metric represents
-	Unit units.Unit
-	// The value of this metric
-	Value *RpcValue
+	// value stored here
+	Value interface{} `json:"value"`
 }
 
 // Metric represents a single metric
@@ -194,8 +118,12 @@ type Metric struct {
 	Value *Value `json:"value"`
 }
 
-// RpcMetricList represents a list of rpc metrics.
-type RpcMetricList []*RpcMetric
-
 // MetricList represents a list of metrics.
 type MetricList []*Metric
+
+func init() {
+	var dur Duration
+	var dist *Distribution
+	gob.Register(dur)
+	gob.Register(dist)
+}

--- a/go/tricorder/messages/duration_test.go
+++ b/go/tricorder/messages/duration_test.go
@@ -1,82 +1,81 @@
-package messages_test
+package messages
 
 import (
-	"github.com/Symantec/tricorder/go/tricorder/messages"
 	"github.com/Symantec/tricorder/go/tricorder/units"
 	"testing"
 	"time"
 )
 
 func TestDuration(t *testing.T) {
-	var expected messages.Duration
+	var expected Duration
 	if expected.IsNegative() {
 		t.Error("Expected duration to be positive.")
 	}
 	var duration time.Duration
-	actual := messages.NewDuration(duration)
+	actual := NewDuration(duration)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
 	if out := expected.AsGoDuration(); out != duration {
 		t.Errorf("Expected %d, got %d", duration, out)
 	}
-	expected = messages.Duration{Seconds: 0, Nanoseconds: 1}
+	expected = Duration{Seconds: 0, Nanoseconds: 1}
 	duration = time.Nanosecond
-	actual = messages.NewDuration(duration)
+	actual = NewDuration(duration)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
 	if out := expected.AsGoDuration(); out != duration {
 		t.Errorf("Expected %d, got %d", duration, out)
 	}
-	expected = messages.Duration{Seconds: 1, Nanoseconds: 0}
+	expected = Duration{Seconds: 1, Nanoseconds: 0}
 	if expected.IsNegative() {
 		t.Error("Expected duration to be positive.")
 	}
 	duration = time.Second
-	actual = messages.NewDuration(duration)
+	actual = NewDuration(duration)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
 	if out := expected.AsGoDuration(); out != duration {
 		t.Errorf("Expected %d, got %d", duration, out)
 	}
-	expected = messages.Duration{Seconds: 1, Nanoseconds: 999999999}
+	expected = Duration{Seconds: 1, Nanoseconds: 999999999}
 	duration = 2*time.Second - time.Nanosecond
-	actual = messages.NewDuration(duration)
+	actual = NewDuration(duration)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
 	if out := expected.AsGoDuration(); out != duration {
 		t.Errorf("Expected %d, got %d", duration, out)
 	}
-	expected = messages.Duration{Seconds: 0, Nanoseconds: -1}
+	expected = Duration{Seconds: 0, Nanoseconds: -1}
 	if !expected.IsNegative() {
 		t.Error("Expected duration to be negative.")
 	}
 	duration = -time.Nanosecond
-	actual = messages.NewDuration(duration)
+	actual = NewDuration(duration)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
 	if out := expected.AsGoDuration(); out != duration {
 		t.Errorf("Expected %d, got %d", duration, out)
 	}
-	expected = messages.Duration{Seconds: -1, Nanoseconds: 0}
+	expected = Duration{Seconds: -1, Nanoseconds: 0}
 	if !expected.IsNegative() {
 		t.Error("Expected duration to be negative.")
 	}
 	duration = -time.Second
-	actual = messages.NewDuration(duration)
+	actual = NewDuration(duration)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
 	if out := expected.AsGoDuration(); out != duration {
 		t.Errorf("Expected %d, got %d", duration, out)
 	}
-	expected = messages.Duration{Seconds: -1, Nanoseconds: -999999999}
+	expected = Duration{Seconds: -1, Nanoseconds: -999999999}
 	duration = -2*time.Second + time.Nanosecond
-	actual = messages.NewDuration(duration)
+	actual = NewDuration(duration)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
@@ -87,63 +86,63 @@ func TestDuration(t *testing.T) {
 
 func TestTime(t *testing.T) {
 	epoch := time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC)
-	var expected messages.Duration
+	var expected Duration
 	tm := epoch
-	actual := messages.SinceEpoch(tm)
+	actual := SinceEpoch(tm)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
 	if out := expected.AsGoTime().UTC(); out != tm {
 		t.Errorf("Expected %d, got %d", tm, out)
 	}
-	expected = messages.Duration{Seconds: 0, Nanoseconds: 1}
+	expected = Duration{Seconds: 0, Nanoseconds: 1}
 	tm = epoch.Add(time.Nanosecond)
-	actual = messages.SinceEpoch(tm)
+	actual = SinceEpoch(tm)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
 	if out := expected.AsGoTime().UTC(); out != tm {
 		t.Errorf("Expected %d, got %d", tm, out)
 	}
-	expected = messages.Duration{Seconds: 1, Nanoseconds: 0}
+	expected = Duration{Seconds: 1, Nanoseconds: 0}
 	tm = epoch.Add(time.Second)
-	actual = messages.SinceEpoch(tm)
+	actual = SinceEpoch(tm)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
 	if out := expected.AsGoTime().UTC(); out != tm {
 		t.Errorf("Expected %d, got %d", tm, out)
 	}
-	expected = messages.Duration{Seconds: 1, Nanoseconds: 999999999}
+	expected = Duration{Seconds: 1, Nanoseconds: 999999999}
 	tm = epoch.Add(2*time.Second - time.Nanosecond)
-	actual = messages.SinceEpoch(tm)
+	actual = SinceEpoch(tm)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
 	if out := expected.AsGoTime().UTC(); out != tm {
 		t.Errorf("Expected %d, got %d", tm, out)
 	}
-	expected = messages.Duration{Seconds: 0, Nanoseconds: -1}
+	expected = Duration{Seconds: 0, Nanoseconds: -1}
 	tm = epoch.Add(-time.Nanosecond)
-	actual = messages.SinceEpoch(tm)
+	actual = SinceEpoch(tm)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
 	if out := expected.AsGoTime().UTC(); out != tm {
 		t.Errorf("Expected %d, got %d", tm, out)
 	}
-	expected = messages.Duration{Seconds: -1, Nanoseconds: 0}
+	expected = Duration{Seconds: -1, Nanoseconds: 0}
 	tm = epoch.Add(-time.Second)
-	actual = messages.SinceEpoch(tm)
+	actual = SinceEpoch(tm)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
 	if out := expected.AsGoTime().UTC(); out != tm {
 		t.Errorf("Expected %d, got %d", tm, out)
 	}
-	expected = messages.Duration{Seconds: -1, Nanoseconds: -999999999}
+	expected = Duration{Seconds: -1, Nanoseconds: -999999999}
 	tm = epoch.Add(-2*time.Second + time.Nanosecond)
-	actual = messages.SinceEpoch(tm)
+	actual = SinceEpoch(tm)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
@@ -153,59 +152,59 @@ func TestTime(t *testing.T) {
 }
 
 func TestString(t *testing.T) {
-	dur := messages.Duration{Seconds: 57}
+	dur := Duration{Seconds: 57}
 	if out := dur.String(); out != "57.000000000" {
 		t.Errorf("Expected 57.000000000, got %s", out)
 	}
-	dur = messages.Duration{Seconds: -53, Nanoseconds: -200000000}
+	dur = Duration{Seconds: -53, Nanoseconds: -200000000}
 	if out := dur.String(); out != "-53.200000000" {
 		t.Errorf("Expected -53.200000000, got %s", out)
 	}
 	if out := dur.StringUsingUnits(units.Millisecond); out != "-53200.000000" {
 		t.Errorf("Expected -53200.000000, got %s", out)
 	}
-	dur = messages.Duration{Seconds: 53, Nanoseconds: 123456789}
+	dur = Duration{Seconds: 53, Nanoseconds: 123456789}
 	if out := dur.StringUsingUnits(units.Millisecond); out != "53123.456789" {
 		t.Errorf("Expected 53123.456789, got %s", out)
 	}
 }
 
 func TestPrettyFormat(t *testing.T) {
-	var dur messages.Duration
+	var dur Duration
 	assertStringEquals(t, "0ns", dur.PrettyFormat())
-	dur = messages.Duration{Nanoseconds: 7}
+	dur = Duration{Nanoseconds: 7}
 	assertStringEquals(t, "7ns", dur.PrettyFormat())
-	dur = messages.Duration{Nanoseconds: 9999}
+	dur = Duration{Nanoseconds: 9999}
 	assertStringEquals(t, "9999ns", dur.PrettyFormat())
-	dur = messages.Duration{Nanoseconds: 10000}
+	dur = Duration{Nanoseconds: 10000}
 	assertStringEquals(t, "10μs", dur.PrettyFormat())
-	dur = messages.Duration{Nanoseconds: 13789}
+	dur = Duration{Nanoseconds: 13789}
 	assertStringEquals(t, "13μs", dur.PrettyFormat())
-	dur = messages.Duration{Nanoseconds: 9999999}
+	dur = Duration{Nanoseconds: 9999999}
 	assertStringEquals(t, "9999μs", dur.PrettyFormat())
-	dur = messages.Duration{Nanoseconds: 10000000}
+	dur = Duration{Nanoseconds: 10000000}
 	assertStringEquals(t, "10ms", dur.PrettyFormat())
-	dur = messages.Duration{Nanoseconds: 678000000}
+	dur = Duration{Nanoseconds: 678000000}
 	assertStringEquals(t, "678ms", dur.PrettyFormat())
-	dur = messages.Duration{Nanoseconds: 999000000}
+	dur = Duration{Nanoseconds: 999000000}
 	assertStringEquals(t, "999ms", dur.PrettyFormat())
-	dur = messages.Duration{Seconds: 1}
+	dur = Duration{Seconds: 1}
 	assertStringEquals(t, "1.000s", dur.PrettyFormat())
-	dur = messages.Duration{Seconds: 35, Nanoseconds: 871000000}
+	dur = Duration{Seconds: 35, Nanoseconds: 871000000}
 	assertStringEquals(t, "35.871s", dur.PrettyFormat())
-	dur = messages.Duration{Seconds: 59, Nanoseconds: 999000000}
+	dur = Duration{Seconds: 59, Nanoseconds: 999000000}
 	assertStringEquals(t, "59.999s", dur.PrettyFormat())
-	dur = messages.Duration{Seconds: 60}
+	dur = Duration{Seconds: 60}
 	assertStringEquals(t, "1m 0.000s", dur.PrettyFormat())
-	dur = messages.Duration{Seconds: 3541, Nanoseconds: 10000000}
+	dur = Duration{Seconds: 3541, Nanoseconds: 10000000}
 	assertStringEquals(t, "59m 1.010s", dur.PrettyFormat())
-	dur = messages.Duration{Seconds: 3600}
+	dur = Duration{Seconds: 3600}
 	assertStringEquals(t, "1h 0m 0s", dur.PrettyFormat())
-	dur = messages.Duration{Seconds: 83000}
+	dur = Duration{Seconds: 83000}
 	assertStringEquals(t, "23h 3m 20s", dur.PrettyFormat())
-	dur = messages.Duration{Seconds: 86400}
+	dur = Duration{Seconds: 86400}
 	assertStringEquals(t, "1d 0h 0m 0s", dur.PrettyFormat())
-	dur = messages.Duration{Seconds: 200000}
+	dur = Duration{Seconds: 200000}
 	assertStringEquals(t, "2d 7h 33m 20s", dur.PrettyFormat())
 }
 

--- a/go/tricorder/metric.go
+++ b/go/tricorder/metric.go
@@ -620,7 +620,7 @@ func (v *value) asJsonOrRpcValue(
 		case goRpcEncoding:
 			return &messages.Value{
 				Kind:  types.TimeStruct,
-				Value: v.AsDuration(s)}
+				Value: v.AsTime(s)}
 		default:
 			panic(panicIncompatibleTypes)
 		}
@@ -632,7 +632,7 @@ func (v *value) asJsonOrRpcValue(
 		case goRpcEncoding:
 			return &messages.Value{
 				Kind:  types.DurationStruct,
-				Value: v.AsDuration(s)}
+				Value: v.AsGoDuration(s)}
 		default:
 			panic(panicIncompatibleTypes)
 		}

--- a/go/tricorder/metric.go
+++ b/go/tricorder/metric.go
@@ -27,6 +27,13 @@ var (
 	intSizeInBits = int(unsafe.Sizeof(0)) * 8
 )
 
+type rpcEncoding int
+
+const (
+	jsonEncoding rpcEncoding = iota
+	goRpcEncoding
+)
+
 var (
 	suffixes = []string{
 		" thousand", " million", " billion", " trillion",
@@ -577,24 +584,10 @@ func (v *value) AsDuration(s *session) (result messages.Duration) {
 	panic(panicIncompatibleTypes)
 }
 
-func asJSONRanges(ranges breakdown) []*messages.RangeWithCount {
+func asRanges(ranges breakdown) []*messages.RangeWithCount {
 	result := make([]*messages.RangeWithCount, len(ranges))
 	for i := range ranges {
-		result[i] = &messages.RangeWithCount{Count: ranges[i].Count}
-		if !ranges[i].First {
-			result[i].Lower = &ranges[i].Start
-		}
-		if !ranges[i].Last {
-			result[i].Upper = &ranges[i].End
-		}
-	}
-	return result
-}
-
-func asRPCRanges(ranges breakdown) []*messages.RpcRangeWithCount {
-	result := make([]*messages.RpcRangeWithCount, len(ranges))
-	for i := range ranges {
-		result[i] = &messages.RpcRangeWithCount{
+		result[i] = &messages.RangeWithCount{
 			Count: ranges[i].Count,
 			Lower: ranges[i].Start,
 			Upper: ranges[i].End}
@@ -602,84 +595,72 @@ func asRPCRanges(ranges breakdown) []*messages.RpcRangeWithCount {
 	return result
 }
 
-// AsJsonValue returns this value as a messages.Value.
-func (v *value) AsJsonValue(s *session) *messages.Value {
+func (v *value) asJsonOrRpcValue(
+	s *session, encoding rpcEncoding) *messages.Value {
 	t := v.Type()
 	switch t {
 	case types.Bool:
-		b := v.AsBool(s)
-		return &messages.Value{Kind: t, BoolValue: &b}
+		return &messages.Value{Kind: t, Value: v.AsBool(s)}
 	case types.Int:
-		i := v.AsInt(s)
 		return &messages.Value{
-			Kind: t, Bits: v.Bits(), IntValue: &i}
+			Kind: t, Bits: v.Bits(), Value: v.AsInt(s)}
 	case types.Uint:
-		u := v.AsUint(s)
 		return &messages.Value{
-			Kind: t, Bits: v.Bits(), UintValue: &u}
+			Kind: t, Bits: v.Bits(), Value: v.AsUint(s)}
 	case types.Float:
-		f := v.AsFloat(s)
 		return &messages.Value{
-			Kind: t, Bits: v.Bits(), FloatValue: &f}
+			Kind: t, Bits: v.Bits(), Value: v.AsFloat(s)}
 	case types.String:
-		s := v.AsString(s)
-		return &messages.Value{Kind: t, StringValue: &s}
-	case types.Time, types.Duration:
-		s := v.AsTextString(s)
-		return &messages.Value{Kind: t, StringValue: &s}
+		return &messages.Value{Kind: t, Value: v.AsString(s)}
+	case types.Time:
+		switch encoding {
+		case jsonEncoding:
+			return &messages.Value{
+				Kind: t, Value: v.AsTextString(s)}
+		case goRpcEncoding:
+			return &messages.Value{
+				Kind:  types.TimeStruct,
+				Value: v.AsDuration(s)}
+		default:
+			panic(panicIncompatibleTypes)
+		}
+	case types.Duration:
+		switch encoding {
+		case jsonEncoding:
+			return &messages.Value{
+				Kind: t, Value: v.AsTextString(s)}
+		case goRpcEncoding:
+			return &messages.Value{
+				Kind:  types.DurationStruct,
+				Value: v.AsDuration(s)}
+		default:
+			panic(panicIncompatibleTypes)
+		}
 	case types.Dist:
 		snapshot := v.AsDistribution().Snapshot()
 		return &messages.Value{
 			Kind: t,
-			DistributionValue: &messages.Distribution{
+			Value: &messages.Distribution{
 				Min:     snapshot.Min,
 				Max:     snapshot.Max,
 				Average: snapshot.Average,
 				Median:  snapshot.Median,
 				Sum:     snapshot.Sum,
 				Count:   snapshot.Count,
-				Ranges:  asJSONRanges(snapshot.Breakdown)}}
+				Ranges:  asRanges(snapshot.Breakdown)}}
 	default:
 		panic(panicIncompatibleTypes)
 	}
 }
 
-// AsRpcValue returns this value as a messages.RpcValue.
-func (v *value) AsRpcValue(s *session) *messages.RpcValue {
-	t := v.Type()
-	switch t {
-	case types.Bool:
-		return &messages.RpcValue{Kind: t, BoolValue: v.AsBool(s)}
-	case types.Int:
-		return &messages.RpcValue{
-			Kind: t, Bits: v.Bits(), IntValue: v.AsInt(s)}
-	case types.Uint:
-		return &messages.RpcValue{
-			Kind: t, Bits: v.Bits(), UintValue: v.AsUint(s)}
-	case types.Float:
-		return &messages.RpcValue{
-			Kind: t, Bits: v.Bits(), FloatValue: v.AsFloat(s)}
-	case types.String:
-		return &messages.RpcValue{
-			Kind: t, StringValue: v.AsString(s)}
-	case types.Time, types.Duration:
-		return &messages.RpcValue{
-			Kind: t, DurationValue: v.AsDuration(s)}
-	case types.Dist:
-		snapshot := v.AsDistribution().Snapshot()
-		return &messages.RpcValue{
-			Kind: t,
-			DistributionValue: &messages.RpcDistribution{
-				Min:     snapshot.Min,
-				Max:     snapshot.Max,
-				Average: snapshot.Average,
-				Median:  snapshot.Median,
-				Sum:     snapshot.Sum,
-				Count:   snapshot.Count,
-				Ranges:  asRPCRanges(snapshot.Breakdown)}}
-	default:
-		panic(panicIncompatibleTypes)
-	}
+// AsJsonValue returns this value as a messages.Value for JSON.
+func (v *value) AsJsonValue(s *session) *messages.Value {
+	return v.asJsonOrRpcValue(s, jsonEncoding)
+}
+
+// AsRpcValue returns this value as a messages.Value for go RPC.
+func (v *value) AsRpcValue(s *session) *messages.Value {
+	return v.asJsonOrRpcValue(s, goRpcEncoding)
 }
 
 // AsTextString returns this value as a text friendly string.

--- a/go/tricorder/metric_test.go
+++ b/go/tricorder/metric_test.go
@@ -507,14 +507,14 @@ func TestAPI(t *testing.T) {
 	assertValueDeepEquals(
 		t,
 		&messages.Value{
-			Kind:        types.String,
-			StringValue: stringPtr("--help")},
+			Kind:  types.String,
+			Value: "--help"},
 		argsMetric.AsJsonValue(nil))
 	assertValueDeepEquals(
 		t,
-		&messages.RpcValue{
-			Kind:        types.String,
-			StringValue: "--help"},
+		&messages.Value{
+			Kind:  types.String,
+			Value: "--help"},
 		argsMetric.AsRpcValue(nil))
 	assertValueEquals(t, "\"--help\"", argsMetric.AsHtmlString(nil))
 
@@ -524,14 +524,14 @@ func TestAPI(t *testing.T) {
 	assertValueDeepEquals(
 		t,
 		&messages.Value{
-			Kind:        types.String,
-			StringValue: stringPtr("My application")},
+			Kind:  types.String,
+			Value: "My application"},
 		nameMetric.AsJsonValue(nil))
 	assertValueDeepEquals(
 		t,
-		&messages.RpcValue{
-			Kind:        types.String,
-			StringValue: "My application"},
+		&messages.Value{
+			Kind:  types.String,
+			Value: "My application"},
 		nameMetric.AsRpcValue(nil))
 	assertValueEquals(t, "\"My application\"", nameMetric.AsHtmlString(nil))
 
@@ -541,16 +541,16 @@ func TestAPI(t *testing.T) {
 	assertValueDeepEquals(
 		t,
 		&messages.Value{
-			Kind:     types.Int,
-			Bits:     32,
-			IntValue: intPtr(934912)},
+			Kind:  types.Int,
+			Bits:  32,
+			Value: int64(934912)},
 		sizeInBytesMetric.AsJsonValue(nil))
 	assertValueDeepEquals(
 		t,
-		&messages.RpcValue{
-			Kind:     types.Int,
-			Bits:     32,
-			IntValue: 934912},
+		&messages.Value{
+			Kind:  types.Int,
+			Bits:  32,
+			Value: int64(934912)},
 		sizeInBytesMetric.AsRpcValue(nil))
 	assertValueEquals(
 		t, "913 KiB", sizeInBytesMetric.AsHtmlString(nil))
@@ -568,16 +568,16 @@ func TestAPI(t *testing.T) {
 	assertValueDeepEquals(
 		t,
 		&messages.Value{
-			Kind:      types.Uint,
-			Bits:      32,
-			UintValue: uintPtr(3538944)},
+			Kind:  types.Uint,
+			Bits:  32,
+			Value: uint64(3538944)},
 		speedInBytesPerSecondMetric.AsJsonValue(nil))
 	assertValueDeepEquals(
 		t,
-		&messages.RpcValue{
-			Kind:      types.Uint,
-			Bits:      32,
-			UintValue: 3538944},
+		&messages.Value{
+			Kind:  types.Uint,
+			Bits:  32,
+			Value: uint64(3538944)},
 		speedInBytesPerSecondMetric.AsRpcValue(nil))
 	assertValueEquals(
 		t,
@@ -594,14 +594,14 @@ func TestAPI(t *testing.T) {
 	assertValueDeepEquals(
 		t,
 		&messages.Value{
-			Kind:        types.Duration,
-			StringValue: stringPtr("-21.053000000")},
+			Kind:  types.Duration,
+			Value: "-21.053000000"},
 		inSecondMetric.AsJsonValue(nil))
 	assertValueDeepEquals(
 		t,
-		&messages.RpcValue{
-			Kind: types.Duration,
-			DurationValue: messages.Duration{
+		&messages.Value{
+			Kind: types.DurationStruct,
+			Value: messages.Duration{
 				Seconds:     -21,
 				Nanoseconds: -53000000,
 			},
@@ -616,14 +616,14 @@ func TestAPI(t *testing.T) {
 	assertValueDeepEquals(
 		t,
 		&messages.Value{
-			Kind:        types.Duration,
-			StringValue: stringPtr("7008.000000")},
+			Kind:  types.Duration,
+			Value: "7008.000000"},
 		inMillisecondMetric.AsJsonValue(nil))
 	assertValueDeepEquals(
 		t,
-		&messages.RpcValue{
-			Kind: types.Duration,
-			DurationValue: messages.Duration{
+		&messages.Value{
+			Kind: types.DurationStruct,
+			Value: messages.Duration{
 				Seconds:     7,
 				Nanoseconds: 8000000,
 			},
@@ -638,16 +638,16 @@ func TestAPI(t *testing.T) {
 	assertValueDeepEquals(
 		t,
 		&messages.Value{
-			Kind:       types.Float,
-			Bits:       64,
-			FloatValue: floatPtr(22.5)},
+			Kind:  types.Float,
+			Bits:  64,
+			Value: 22.5},
 		temperatureMetric.AsJsonValue(nil))
 	assertValueDeepEquals(
 		t,
-		&messages.RpcValue{
-			Kind:       types.Float,
-			Bits:       64,
-			FloatValue: 22.5},
+		&messages.Value{
+			Kind:  types.Float,
+			Bits:  64,
+			Value: 22.5},
 		temperatureMetric.AsRpcValue(nil))
 	assertValueEquals(t, "22.5", temperatureMetric.AsHtmlString(nil))
 
@@ -657,16 +657,16 @@ func TestAPI(t *testing.T) {
 	assertValueDeepEquals(
 		t,
 		&messages.Value{
-			Kind:     types.Int,
-			Bits:     64,
-			IntValue: intPtr(-1234567)},
+			Kind:  types.Int,
+			Bits:  64,
+			Value: int64(-1234567)},
 		startTimeMetric.AsJsonValue(nil))
 	assertValueDeepEquals(
 		t,
-		&messages.RpcValue{
-			Kind:     types.Int,
-			Bits:     64,
-			IntValue: -1234567},
+		&messages.Value{
+			Kind:  types.Int,
+			Bits:  64,
+			Value: int64(-1234567)},
 		startTimeMetric.AsRpcValue(nil))
 	assertValueEquals(t, "-1234567", startTimeMetric.AsTextString(nil))
 	assertValueEquals(t, "-1.23 million", startTimeMetric.AsHtmlString(nil))
@@ -677,14 +677,14 @@ func TestAPI(t *testing.T) {
 	assertValueDeepEquals(
 		t,
 		&messages.Value{
-			Kind:        types.Time,
-			StringValue: stringPtr("1447594013.007265341")},
+			Kind:  types.Time,
+			Value: "1447594013.007265341"},
 		someTimeMetric.AsJsonValue(nil))
 	assertValueDeepEquals(
 		t,
-		&messages.RpcValue{
-			Kind: types.Time,
-			DurationValue: messages.Duration{
+		&messages.Value{
+			Kind: types.TimeStruct,
+			Value: messages.Duration{
 				Seconds:     1447594013,
 				Nanoseconds: 7265341},
 		},
@@ -698,13 +698,14 @@ func TestAPI(t *testing.T) {
 	assertValueDeepEquals(
 		t,
 		&messages.Value{
-			Kind:        types.Time,
-			StringValue: stringPtr("0.000000000")},
+			Kind:  types.Time,
+			Value: "0.000000000"},
 		someTimePtrMetric.AsJsonValue(nil))
 	assertValueDeepEquals(
 		t,
-		&messages.RpcValue{
-			Kind: types.Time,
+		&messages.Value{
+			Kind:  types.TimeStruct,
+			Value: messages.Duration{},
 		},
 		someTimePtrMetric.AsRpcValue(nil))
 	assertValueEquals(t, "0001-01-01T00:00:00Z", someTimePtrMetric.AsHtmlString(nil))
@@ -714,14 +715,14 @@ func TestAPI(t *testing.T) {
 	assertValueDeepEquals(
 		t,
 		&messages.Value{
-			Kind:        types.Time,
-			StringValue: stringPtr("1441517195.000000000")},
+			Kind:  types.Time,
+			Value: "1441517195.000000000"},
 		someTimePtrMetric.AsJsonValue(nil))
 	assertValueDeepEquals(
 		t,
-		&messages.RpcValue{
-			Kind: types.Time,
-			DurationValue: messages.Duration{
+		&messages.Value{
+			Kind: types.TimeStruct,
+			Value: messages.Duration{
 				Seconds: 1441517195,
 			},
 		},
@@ -737,16 +738,16 @@ func TestAPI(t *testing.T) {
 	assertValueDeepEquals(
 		t,
 		&messages.Value{
-			Kind:      types.Uint,
-			Bits:      64,
-			UintValue: uintPtr(500)},
+			Kind:  types.Uint,
+			Bits:  64,
+			Value: uint64(500)},
 		rpcCountMetric.AsJsonValue(nil))
 	assertValueDeepEquals(
 		t,
-		&messages.RpcValue{
-			Kind:      types.Uint,
-			Bits:      64,
-			UintValue: 500},
+		&messages.Value{
+			Kind:  types.Uint,
+			Bits:  64,
+			Value: uint64(500)},
 		rpcCountMetric.AsRpcValue(nil))
 	assertValueEquals(t, "500", rpcCountMetric.AsHtmlString(nil))
 
@@ -756,16 +757,16 @@ func TestAPI(t *testing.T) {
 	assertValueDeepEquals(
 		t,
 		&messages.Value{
-			Kind:       types.Float,
-			Bits:       32,
-			FloatValue: floatPtr(12.375)},
+			Kind:  types.Float,
+			Bits:  32,
+			Value: 12.375},
 		bazMetric.AsJsonValue(nil))
 	assertValueDeepEquals(
 		t,
-		&messages.RpcValue{
-			Kind:       types.Float,
-			Bits:       32,
-			FloatValue: 12.375},
+		&messages.Value{
+			Kind:  types.Float,
+			Bits:  32,
+			Value: 12.375},
 		bazMetric.AsRpcValue(nil))
 	assertValueEquals(t, "12.375", bazMetric.AsHtmlString(nil))
 
@@ -775,14 +776,14 @@ func TestAPI(t *testing.T) {
 	assertValueDeepEquals(
 		t,
 		&messages.Value{
-			Kind:      types.Bool,
-			BoolValue: boolPtr(true)},
+			Kind:  types.Bool,
+			Value: true},
 		aboolMetric.AsJsonValue(nil))
 	assertValueDeepEquals(
 		t,
-		&messages.RpcValue{
-			Kind:      types.Bool,
-			BoolValue: true},
+		&messages.Value{
+			Kind:  types.Bool,
+			Value: true},
 		aboolMetric.AsRpcValue(nil))
 	assertValueEquals(t, "true", aboolMetric.AsHtmlString(nil))
 
@@ -792,14 +793,14 @@ func TestAPI(t *testing.T) {
 	assertValueDeepEquals(
 		t,
 		&messages.Value{
-			Kind:      types.Bool,
-			BoolValue: boolPtr(false)},
+			Kind:  types.Bool,
+			Value: false},
 		anotherBoolMetric.AsJsonValue(nil))
 	assertValueDeepEquals(
 		t,
-		&messages.RpcValue{
-			Kind: types.Bool,
-		},
+		&messages.Value{
+			Kind:  types.Bool,
+			Value: false},
 		anotherBoolMetric.AsRpcValue(nil))
 	assertValueEquals(t, "false", anotherBoolMetric.AsHtmlString(nil))
 
@@ -809,46 +810,46 @@ func TestAPI(t *testing.T) {
 
 	actual := rpcLatency.AsJsonValue(nil)
 
-	if actual.DistributionValue.Median < 249 || actual.DistributionValue.Median >= 250 {
-		t.Errorf("Median out of range: %f", actual.DistributionValue.Median)
+	if actual.Value.(*messages.Distribution).Median < 249 || actual.Value.(*messages.Distribution).Median >= 250 {
+		t.Errorf("Median out of range: %f", actual.Value.(*messages.Distribution).Median)
 	}
 
 	expected := &messages.Value{
 		Kind: types.Dist,
-		DistributionValue: &messages.Distribution{
+		Value: &messages.Distribution{
 			Min:     0.0,
 			Max:     499.0,
 			Average: 249.5,
 			Sum:     124750.0,
-			Median:  actual.DistributionValue.Median,
+			Median:  actual.Value.(*messages.Distribution).Median,
 			Count:   500,
 			Ranges: []*messages.RangeWithCount{
 				{
-					Upper: floatPtr(10.0),
+					Upper: 10.0,
 					Count: 10,
 				},
 				{
-					Lower: floatPtr(10.0),
-					Upper: floatPtr(25.0),
+					Lower: 10.0,
+					Upper: 25.0,
 					Count: 15,
 				},
 				{
-					Lower: floatPtr(25.0),
-					Upper: floatPtr(62.5),
+					Lower: 25.0,
+					Upper: 62.5,
 					Count: 38,
 				},
 				{
-					Lower: floatPtr(62.5),
-					Upper: floatPtr(156.25),
+					Lower: 62.5,
+					Upper: 156.25,
 					Count: 94,
 				},
 				{
-					Lower: floatPtr(156.25),
-					Upper: floatPtr(390.625),
+					Lower: 156.25,
+					Upper: 390.625,
 					Count: 234,
 				},
 				{
-					Lower: floatPtr(390.625),
+					Lower: 390.625,
 					Count: 109,
 				},
 			},
@@ -858,20 +859,20 @@ func TestAPI(t *testing.T) {
 
 	actualRpc := rpcLatency.AsRpcValue(nil)
 
-	if actualRpc.DistributionValue.Median < 249 || actualRpc.DistributionValue.Median >= 250 {
-		t.Errorf("Median out of range in rpc: %f", actualRpc.DistributionValue.Median)
+	if actualRpc.Value.(*messages.Distribution).Median < 249 || actualRpc.Value.(*messages.Distribution).Median >= 250 {
+		t.Errorf("Median out of range in rpc: %f", actualRpc.Value.(*messages.Distribution).Median)
 	}
 
-	expectedRpc := &messages.RpcValue{
+	expectedRpc := &messages.Value{
 		Kind: types.Dist,
-		DistributionValue: &messages.RpcDistribution{
+		Value: &messages.Distribution{
 			Min:     0.0,
 			Max:     499.0,
 			Average: 249.5,
 			Sum:     124750.0,
-			Median:  actualRpc.DistributionValue.Median,
+			Median:  actualRpc.Value.(*messages.Distribution).Median,
 			Count:   500,
-			Ranges: []*messages.RpcRangeWithCount{
+			Ranges: []*messages.RangeWithCount{
 				{
 					Upper: 10.0,
 					Count: 10,
@@ -1145,7 +1146,7 @@ func verifyMetric(
 	if desc != m.Description {
 		t.Errorf("Expected %s, got %s", desc, m.Description)
 	}
-	if unit != m.Unit {
+	if unit != m.Unit() {
 		t.Errorf("Expected %v, got %v", unit, m.Unit)
 	}
 }
@@ -1214,24 +1215,4 @@ func verifyGetAllMetricsByPath(
 	if !reflect.DeepEqual(expectedPaths, ([]string)(actual)) {
 		t.Errorf("Expected %v, got %v", expectedPaths, actual)
 	}
-}
-
-func stringPtr(s string) *string {
-	return &s
-}
-
-func intPtr(i int64) *int64 {
-	return &i
-}
-
-func uintPtr(u uint64) *uint64 {
-	return &u
-}
-
-func floatPtr(f float64) *float64 {
-	return &f
-}
-
-func boolPtr(b bool) *bool {
-	return &b
 }

--- a/go/tricorder/metric_test.go
+++ b/go/tricorder/metric_test.go
@@ -600,11 +600,8 @@ func TestAPI(t *testing.T) {
 	assertValueDeepEquals(
 		t,
 		&messages.Value{
-			Kind: types.DurationStruct,
-			Value: messages.Duration{
-				Seconds:     -21,
-				Nanoseconds: -53000000,
-			},
+			Kind:  types.DurationStruct,
+			Value: -21*time.Second - 53*time.Millisecond,
 		},
 		inSecondMetric.AsRpcValue(nil))
 	assertValueEquals(t, "-21.053000000", inSecondMetric.AsHtmlString(nil))
@@ -622,11 +619,8 @@ func TestAPI(t *testing.T) {
 	assertValueDeepEquals(
 		t,
 		&messages.Value{
-			Kind: types.DurationStruct,
-			Value: messages.Duration{
-				Seconds:     7,
-				Nanoseconds: 8000000,
-			},
+			Kind:  types.DurationStruct,
+			Value: 7*time.Second + 8*time.Millisecond,
 		},
 		inMillisecondMetric.AsRpcValue(nil))
 	assertValueEquals(t, "7.008s", inMillisecondMetric.AsHtmlString(nil))
@@ -683,10 +677,8 @@ func TestAPI(t *testing.T) {
 	assertValueDeepEquals(
 		t,
 		&messages.Value{
-			Kind: types.TimeStruct,
-			Value: messages.Duration{
-				Seconds:     1447594013,
-				Nanoseconds: 7265341},
+			Kind:  types.TimeStruct,
+			Value: someTime,
 		},
 		someTimeMetric.AsRpcValue(nil))
 	assertValueEquals(t, "2015-11-15T13:26:53.007265341Z", someTimeMetric.AsHtmlString(nil))
@@ -705,7 +697,7 @@ func TestAPI(t *testing.T) {
 		t,
 		&messages.Value{
 			Kind:  types.TimeStruct,
-			Value: messages.Duration{},
+			Value: time.Time{},
 		},
 		someTimePtrMetric.AsRpcValue(nil))
 	assertValueEquals(t, "0001-01-01T00:00:00Z", someTimePtrMetric.AsHtmlString(nil))
@@ -721,10 +713,8 @@ func TestAPI(t *testing.T) {
 	assertValueDeepEquals(
 		t,
 		&messages.Value{
-			Kind: types.TimeStruct,
-			Value: messages.Duration{
-				Seconds: 1441517195,
-			},
+			Kind:  types.TimeStruct,
+			Value: newTime,
 		},
 		someTimePtrMetric.AsRpcValue(nil))
 	assertValueEquals(

--- a/go/tricorder/rpc.go
+++ b/go/tricorder/rpc.go
@@ -5,15 +5,15 @@ import (
 	"net/rpc"
 )
 
-func rpcAsMetric(m *metric, s *session) *messages.RpcMetric {
-	return &messages.RpcMetric{
+func rpcAsMetric(m *metric, s *session) *messages.Metric {
+	return &messages.Metric{
 		Path:        m.AbsPath(),
 		Description: m.Description,
 		Unit:        m.Unit(),
 		Value:       m.AsRpcValue(s)}
 }
 
-type rpcMetricsCollector messages.RpcMetricList
+type rpcMetricsCollector messages.MetricList
 
 func (c *rpcMetricsCollector) Collect(m *metric, s *session) (err error) {
 	*c = append(*c, rpcAsMetric(m, s))
@@ -22,12 +22,12 @@ func (c *rpcMetricsCollector) Collect(m *metric, s *session) (err error) {
 
 type rpcType int
 
-func (t *rpcType) ListMetrics(path string, response *messages.RpcMetricList) error {
+func (t *rpcType) ListMetrics(path string, response *messages.MetricList) error {
 	return root.GetAllMetricsByPath(
 		path, (*rpcMetricsCollector)(response), nil)
 }
 
-func (t *rpcType) GetMetric(path string, response *messages.RpcMetric) error {
+func (t *rpcType) GetMetric(path string, response *messages.Metric) error {
 	m := root.GetMetric(path)
 	if m == nil {
 		return messages.ErrMetricNotFound

--- a/go/tricorder/types/api.go
+++ b/go/tricorder/types/api.go
@@ -13,4 +13,9 @@ const (
 	Dist     Type = "distribution"
 	Time     Type = "time"
 	Duration Type = "duration"
+
+	// Used only in GoRPC
+	TimeStruct Type = "timeStruct"
+	// Used only in GoRPC
+	DurationStruct Type = "durationStruct"
 )

--- a/go/tricorderclient/tricorderclient.go
+++ b/go/tricorderclient/tricorderclient.go
@@ -29,7 +29,7 @@ func main() {
 		log.Fatal("dialing:", err)
 	}
 	defer client.Close()
-	var metrics messages.RpcMetricList
+	var metrics messages.MetricList
 	err = client.Call("MetricsServer.ListMetrics", "", &metrics)
 	if err != nil {
 		log.Fatal("Calling:", err)
@@ -42,7 +42,7 @@ func main() {
 	}
 	printAsJson("aaa/bbb metrics", metrics)
 
-	var single messages.RpcMetric
+	var single messages.Metric
 	err = client.Call("MetricsServer.GetMetric", "/proc/foo/bar/baz", &single)
 	if err != nil {
 		log.Fatal("Calling:", err)


### PR DESCRIPTION
allows single data type for both json and rpc.
