### PR TITLE
More refactorings we had discussed.

### DIFF
--- a/go/tricorder/duration_test.go
+++ b/go/tricorder/duration_test.go
@@ -1,4 +1,4 @@
-package messages
+package tricorder
 
 import (
 	"github.com/Symantec/tricorder/go/tricorder/units"
@@ -7,142 +7,142 @@ import (
 )
 
 func TestDuration(t *testing.T) {
-	var expected Duration
+	var expected duration
 	if expected.IsNegative() {
 		t.Error("Expected duration to be positive.")
 	}
-	var duration time.Duration
-	actual := NewDuration(duration)
+	var dur time.Duration
+	actual := newDuration(dur)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
-	if out := expected.AsGoDuration(); out != duration {
-		t.Errorf("Expected %d, got %d", duration, out)
+	if out := expected.AsGoDuration(); out != dur {
+		t.Errorf("Expected %d, got %d", dur, out)
 	}
-	expected = Duration{Seconds: 0, Nanoseconds: 1}
-	duration = time.Nanosecond
-	actual = NewDuration(duration)
+	expected = duration{Seconds: 0, Nanoseconds: 1}
+	dur = time.Nanosecond
+	actual = newDuration(dur)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
-	if out := expected.AsGoDuration(); out != duration {
-		t.Errorf("Expected %d, got %d", duration, out)
+	if out := expected.AsGoDuration(); out != dur {
+		t.Errorf("Expected %d, got %d", dur, out)
 	}
-	expected = Duration{Seconds: 1, Nanoseconds: 0}
+	expected = duration{Seconds: 1, Nanoseconds: 0}
 	if expected.IsNegative() {
 		t.Error("Expected duration to be positive.")
 	}
-	duration = time.Second
-	actual = NewDuration(duration)
+	dur = time.Second
+	actual = newDuration(dur)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
-	if out := expected.AsGoDuration(); out != duration {
-		t.Errorf("Expected %d, got %d", duration, out)
+	if out := expected.AsGoDuration(); out != dur {
+		t.Errorf("Expected %d, got %d", dur, out)
 	}
-	expected = Duration{Seconds: 1, Nanoseconds: 999999999}
-	duration = 2*time.Second - time.Nanosecond
-	actual = NewDuration(duration)
+	expected = duration{Seconds: 1, Nanoseconds: 999999999}
+	dur = 2*time.Second - time.Nanosecond
+	actual = newDuration(dur)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
-	if out := expected.AsGoDuration(); out != duration {
-		t.Errorf("Expected %d, got %d", duration, out)
+	if out := expected.AsGoDuration(); out != dur {
+		t.Errorf("Expected %d, got %d", dur, out)
 	}
-	expected = Duration{Seconds: 0, Nanoseconds: -1}
+	expected = duration{Seconds: 0, Nanoseconds: -1}
 	if !expected.IsNegative() {
 		t.Error("Expected duration to be negative.")
 	}
-	duration = -time.Nanosecond
-	actual = NewDuration(duration)
+	dur = -time.Nanosecond
+	actual = newDuration(dur)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
-	if out := expected.AsGoDuration(); out != duration {
-		t.Errorf("Expected %d, got %d", duration, out)
+	if out := expected.AsGoDuration(); out != dur {
+		t.Errorf("Expected %d, got %d", dur, out)
 	}
-	expected = Duration{Seconds: -1, Nanoseconds: 0}
+	expected = duration{Seconds: -1, Nanoseconds: 0}
 	if !expected.IsNegative() {
 		t.Error("Expected duration to be negative.")
 	}
-	duration = -time.Second
-	actual = NewDuration(duration)
+	dur = -time.Second
+	actual = newDuration(dur)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
-	if out := expected.AsGoDuration(); out != duration {
-		t.Errorf("Expected %d, got %d", duration, out)
+	if out := expected.AsGoDuration(); out != dur {
+		t.Errorf("Expected %d, got %d", dur, out)
 	}
-	expected = Duration{Seconds: -1, Nanoseconds: -999999999}
-	duration = -2*time.Second + time.Nanosecond
-	actual = NewDuration(duration)
+	expected = duration{Seconds: -1, Nanoseconds: -999999999}
+	dur = -2*time.Second + time.Nanosecond
+	actual = newDuration(dur)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
-	if out := expected.AsGoDuration(); out != duration {
-		t.Errorf("Expected %d, got %d", duration, out)
+	if out := expected.AsGoDuration(); out != dur {
+		t.Errorf("Expected %d, got %d", dur, out)
 	}
 }
 
 func TestTime(t *testing.T) {
 	epoch := time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC)
-	var expected Duration
+	var expected duration
 	tm := epoch
-	actual := SinceEpoch(tm)
+	actual := durationSinceEpoch(tm)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
 	if out := expected.AsGoTime().UTC(); out != tm {
 		t.Errorf("Expected %d, got %d", tm, out)
 	}
-	expected = Duration{Seconds: 0, Nanoseconds: 1}
+	expected = duration{Seconds: 0, Nanoseconds: 1}
 	tm = epoch.Add(time.Nanosecond)
-	actual = SinceEpoch(tm)
+	actual = durationSinceEpoch(tm)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
 	if out := expected.AsGoTime().UTC(); out != tm {
 		t.Errorf("Expected %d, got %d", tm, out)
 	}
-	expected = Duration{Seconds: 1, Nanoseconds: 0}
+	expected = duration{Seconds: 1, Nanoseconds: 0}
 	tm = epoch.Add(time.Second)
-	actual = SinceEpoch(tm)
+	actual = durationSinceEpoch(tm)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
 	if out := expected.AsGoTime().UTC(); out != tm {
 		t.Errorf("Expected %d, got %d", tm, out)
 	}
-	expected = Duration{Seconds: 1, Nanoseconds: 999999999}
+	expected = duration{Seconds: 1, Nanoseconds: 999999999}
 	tm = epoch.Add(2*time.Second - time.Nanosecond)
-	actual = SinceEpoch(tm)
+	actual = durationSinceEpoch(tm)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
 	if out := expected.AsGoTime().UTC(); out != tm {
 		t.Errorf("Expected %d, got %d", tm, out)
 	}
-	expected = Duration{Seconds: 0, Nanoseconds: -1}
+	expected = duration{Seconds: 0, Nanoseconds: -1}
 	tm = epoch.Add(-time.Nanosecond)
-	actual = SinceEpoch(tm)
+	actual = durationSinceEpoch(tm)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
 	if out := expected.AsGoTime().UTC(); out != tm {
 		t.Errorf("Expected %d, got %d", tm, out)
 	}
-	expected = Duration{Seconds: -1, Nanoseconds: 0}
+	expected = duration{Seconds: -1, Nanoseconds: 0}
 	tm = epoch.Add(-time.Second)
-	actual = SinceEpoch(tm)
+	actual = durationSinceEpoch(tm)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
 	if out := expected.AsGoTime().UTC(); out != tm {
 		t.Errorf("Expected %d, got %d", tm, out)
 	}
-	expected = Duration{Seconds: -1, Nanoseconds: -999999999}
+	expected = duration{Seconds: -1, Nanoseconds: -999999999}
 	tm = epoch.Add(-2*time.Second + time.Nanosecond)
-	actual = SinceEpoch(tm)
+	actual = durationSinceEpoch(tm)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
@@ -152,59 +152,59 @@ func TestTime(t *testing.T) {
 }
 
 func TestString(t *testing.T) {
-	dur := Duration{Seconds: 57}
+	dur := duration{Seconds: 57}
 	if out := dur.String(); out != "57.000000000" {
 		t.Errorf("Expected 57.000000000, got %s", out)
 	}
-	dur = Duration{Seconds: -53, Nanoseconds: -200000000}
+	dur = duration{Seconds: -53, Nanoseconds: -200000000}
 	if out := dur.String(); out != "-53.200000000" {
 		t.Errorf("Expected -53.200000000, got %s", out)
 	}
 	if out := dur.StringUsingUnits(units.Millisecond); out != "-53200.000000" {
 		t.Errorf("Expected -53200.000000, got %s", out)
 	}
-	dur = Duration{Seconds: 53, Nanoseconds: 123456789}
+	dur = duration{Seconds: 53, Nanoseconds: 123456789}
 	if out := dur.StringUsingUnits(units.Millisecond); out != "53123.456789" {
 		t.Errorf("Expected 53123.456789, got %s", out)
 	}
 }
 
 func TestPrettyFormat(t *testing.T) {
-	var dur Duration
+	var dur duration
 	assertStringEquals(t, "0ns", dur.PrettyFormat())
-	dur = Duration{Nanoseconds: 7}
+	dur = duration{Nanoseconds: 7}
 	assertStringEquals(t, "7ns", dur.PrettyFormat())
-	dur = Duration{Nanoseconds: 9999}
+	dur = duration{Nanoseconds: 9999}
 	assertStringEquals(t, "9999ns", dur.PrettyFormat())
-	dur = Duration{Nanoseconds: 10000}
+	dur = duration{Nanoseconds: 10000}
 	assertStringEquals(t, "10μs", dur.PrettyFormat())
-	dur = Duration{Nanoseconds: 13789}
+	dur = duration{Nanoseconds: 13789}
 	assertStringEquals(t, "13μs", dur.PrettyFormat())
-	dur = Duration{Nanoseconds: 9999999}
+	dur = duration{Nanoseconds: 9999999}
 	assertStringEquals(t, "9999μs", dur.PrettyFormat())
-	dur = Duration{Nanoseconds: 10000000}
+	dur = duration{Nanoseconds: 10000000}
 	assertStringEquals(t, "10ms", dur.PrettyFormat())
-	dur = Duration{Nanoseconds: 678000000}
+	dur = duration{Nanoseconds: 678000000}
 	assertStringEquals(t, "678ms", dur.PrettyFormat())
-	dur = Duration{Nanoseconds: 999000000}
+	dur = duration{Nanoseconds: 999000000}
 	assertStringEquals(t, "999ms", dur.PrettyFormat())
-	dur = Duration{Seconds: 1}
+	dur = duration{Seconds: 1}
 	assertStringEquals(t, "1.000s", dur.PrettyFormat())
-	dur = Duration{Seconds: 35, Nanoseconds: 871000000}
+	dur = duration{Seconds: 35, Nanoseconds: 871000000}
 	assertStringEquals(t, "35.871s", dur.PrettyFormat())
-	dur = Duration{Seconds: 59, Nanoseconds: 999000000}
+	dur = duration{Seconds: 59, Nanoseconds: 999000000}
 	assertStringEquals(t, "59.999s", dur.PrettyFormat())
-	dur = Duration{Seconds: 60}
+	dur = duration{Seconds: 60}
 	assertStringEquals(t, "1m 0.000s", dur.PrettyFormat())
-	dur = Duration{Seconds: 3541, Nanoseconds: 10000000}
+	dur = duration{Seconds: 3541, Nanoseconds: 10000000}
 	assertStringEquals(t, "59m 1.010s", dur.PrettyFormat())
-	dur = Duration{Seconds: 3600}
+	dur = duration{Seconds: 3600}
 	assertStringEquals(t, "1h 0m 0s", dur.PrettyFormat())
-	dur = Duration{Seconds: 83000}
+	dur = duration{Seconds: 83000}
 	assertStringEquals(t, "23h 3m 20s", dur.PrettyFormat())
-	dur = Duration{Seconds: 86400}
+	dur = duration{Seconds: 86400}
 	assertStringEquals(t, "1d 0h 0m 0s", dur.PrettyFormat())
-	dur = Duration{Seconds: 200000}
+	dur = duration{Seconds: 200000}
 	assertStringEquals(t, "2d 7h 33m 20s", dur.PrettyFormat())
 }
 

--- a/go/tricorder/json.go
+++ b/go/tricorder/json.go
@@ -12,11 +12,12 @@ var (
 )
 
 func jsonAsMetric(m *metric, s *session) *messages.Metric {
-	return &messages.Metric{
+	result := messages.Metric{
 		Path:        m.AbsPath(),
 		Description: m.Description,
-		Unit:        m.Unit(),
-		Value:       m.AsJsonValue(s)}
+		Unit:        m.Unit()}
+	m.UpdateJsonMetric(s, &result)
+	return &result
 }
 
 type jsonMetricsCollector messages.MetricList

--- a/go/tricorder/messages/api.go
+++ b/go/tricorder/messages/api.go
@@ -47,16 +47,6 @@ type Distribution struct {
 	Ranges []*RangeWithCount `json:"ranges,omitempty"`
 }
 
-// Value represents the value of a metric.
-type Value struct {
-	// The value's type
-	Kind types.Type `json:"kind"`
-	// The value's size in bits if Int, Uint, or float
-	Bits int `json:"bits,omitempty"`
-	// value stored here
-	Value interface{} `json:"value"`
-}
-
 // Metric represents a single metric
 type Metric struct {
 	// The absolute path to this metric
@@ -65,8 +55,12 @@ type Metric struct {
 	Description string `json:"description"`
 	// The unit of measurement this metric represents
 	Unit units.Unit `json:"unit"`
-	// The value of this metric
-	Value *Value `json:"value"`
+	// The metric's type
+	Kind types.Type `json:"kind"`
+	// The size in bits of metric's value if Int, Uint, or float
+	Bits int `json:"bits,omitempty"`
+	// value stored here
+	Value interface{} `json:"value"`
 }
 
 // MetricList represents a list of metrics.

--- a/go/tricorder/messages/api.go
+++ b/go/tricorder/messages/api.go
@@ -47,55 +47,6 @@ type Distribution struct {
 	Ranges []*RangeWithCount `json:"ranges,omitempty"`
 }
 
-// Duration represents a duration of time
-// For negative durations, both Seconds and Nanoseconds are negative.
-type Duration struct {
-	Seconds     int64
-	Nanoseconds int32
-}
-
-func NewDuration(d time.Duration) Duration {
-	return newDuration(d)
-}
-
-// SinceEpoch returns the amount of time since unix epoch
-func SinceEpoch(t time.Time) Duration {
-	return sinceEpoch(t)
-}
-
-// AsGoDuration converts this duration to a go duration
-func (d Duration) AsGoDuration() time.Duration {
-	return d.asGoDuration()
-}
-
-// AsGoTime Converts this duration to a go time.
-// This is the inverse of SinceEpoch.
-func (d Duration) AsGoTime() time.Time {
-	return d.asGoTime()
-}
-
-// String shows in seconds
-func (d Duration) String() string {
-	return d.stringUsingUnits(units.Second)
-}
-
-// StringUsingUnits shows in specified time unit.
-// If unit not a time, shows in seconds.
-func (d Duration) StringUsingUnits(unit units.Unit) string {
-	return d.stringUsingUnits(unit)
-}
-
-// IsNegative returns true if this duration is negative.
-func (d Duration) IsNegative() bool {
-	return d.isNegative()
-}
-
-// PrettyFormat pretty formats this duration.
-// PrettyFormat panics if this duration is negative.
-func (d Duration) PrettyFormat() string {
-	return d.prettyFormat()
-}
-
 // Value represents the value of a metric.
 type Value struct {
 	// The value's type

--- a/go/tricorder/metric.go
+++ b/go/tricorder/metric.go
@@ -570,16 +570,16 @@ func (v *value) AsGoDuration(s *session) time.Duration {
 	return time.Duration(v.evaluate(s).Int())
 }
 
-func (v *value) AsDuration(s *session) (result messages.Duration) {
+func (v *value) AsDuration(s *session) (result duration) {
 	if v.valType == types.Time {
 		t := v.AsTime(s)
 		if t.IsZero() {
 			return
 		}
-		return messages.SinceEpoch(t)
+		return durationSinceEpoch(t)
 	}
 	if v.valType == types.Duration {
-		return messages.NewDuration(v.AsGoDuration(s))
+		return newDuration(v.AsGoDuration(s))
 	}
 	panic(panicIncompatibleTypes)
 }

--- a/go/tricorder/metric.go
+++ b/go/tricorder/metric.go
@@ -595,72 +595,72 @@ func asRanges(ranges breakdown) []*messages.RangeWithCount {
 	return result
 }
 
-func (v *value) asJsonOrRpcValue(
-	s *session, encoding rpcEncoding) *messages.Value {
+func (v *value) updateJsonOrRpcMetric(
+	s *session, metric *messages.Metric, encoding rpcEncoding) {
 	t := v.Type()
+	metric.Bits = v.Bits()
 	switch t {
 	case types.Bool:
-		return &messages.Value{Kind: t, Value: v.AsBool(s)}
+		metric.Kind = t
+		metric.Value = v.AsBool(s)
 	case types.Int:
-		return &messages.Value{
-			Kind: t, Bits: v.Bits(), Value: v.AsInt(s)}
+		metric.Kind = t
+		metric.Value = v.AsInt(s)
 	case types.Uint:
-		return &messages.Value{
-			Kind: t, Bits: v.Bits(), Value: v.AsUint(s)}
+		metric.Kind = t
+		metric.Value = v.AsUint(s)
 	case types.Float:
-		return &messages.Value{
-			Kind: t, Bits: v.Bits(), Value: v.AsFloat(s)}
+		metric.Kind = t
+		metric.Value = v.AsFloat(s)
 	case types.String:
-		return &messages.Value{Kind: t, Value: v.AsString(s)}
+		metric.Kind = t
+		metric.Value = v.AsString(s)
 	case types.Time:
 		switch encoding {
 		case jsonEncoding:
-			return &messages.Value{
-				Kind: t, Value: v.AsTextString(s)}
+			metric.Kind = t
+			metric.Value = v.AsTextString(s)
 		case goRpcEncoding:
-			return &messages.Value{
-				Kind:  types.GoTime,
-				Value: v.AsTime(s)}
+			metric.Kind = types.GoTime
+			metric.Value = v.AsTime(s)
 		default:
 			panic(panicIncompatibleTypes)
 		}
 	case types.Duration:
 		switch encoding {
 		case jsonEncoding:
-			return &messages.Value{
-				Kind: t, Value: v.AsTextString(s)}
+			metric.Kind = t
+			metric.Value = v.AsTextString(s)
 		case goRpcEncoding:
-			return &messages.Value{
-				Kind:  types.GoDuration,
-				Value: v.AsGoDuration(s)}
+			metric.Kind = types.GoDuration
+			metric.Value = v.AsGoDuration(s)
 		default:
 			panic(panicIncompatibleTypes)
 		}
 	case types.Dist:
 		snapshot := v.AsDistribution().Snapshot()
-		return &messages.Value{
-			Kind: t,
-			Value: &messages.Distribution{
-				Min:     snapshot.Min,
-				Max:     snapshot.Max,
-				Average: snapshot.Average,
-				Median:  snapshot.Median,
-				Sum:     snapshot.Sum,
-				Count:   snapshot.Count,
-				Ranges:  asRanges(snapshot.Breakdown)}}
+		metric.Kind = t
+		metric.Value = &messages.Distribution{
+			Min:     snapshot.Min,
+			Max:     snapshot.Max,
+			Average: snapshot.Average,
+			Median:  snapshot.Median,
+			Sum:     snapshot.Sum,
+			Count:   snapshot.Count,
+			Ranges:  asRanges(snapshot.Breakdown)}
 	default:
 		panic(panicIncompatibleTypes)
 	}
 }
 
-// AsJsonValue returns this value as a messages.Value for JSON.
-func (v *value) AsJsonValue(s *session) *messages.Value {
-	return v.asJsonOrRpcValue(s, jsonEncoding)
+// UpdateJsonMetric updates fields in metric for JSON.
+func (v *value) UpdateJsonMetric(s *session, metric *messages.Metric) {
+	v.updateJsonOrRpcMetric(s, metric, jsonEncoding)
 }
 
-// AsRpcValue returns this value as a messages.Value for go RPC.
-func (v *value) AsRpcValue(s *session) *messages.Value {
-	return v.asJsonOrRpcValue(s, goRpcEncoding)
+// UpdateRpcMetric updates fields in this metric for go RPC.
+func (v *value) UpdateRpcMetric(s *session, metric *messages.Metric) {
+	v.updateJsonOrRpcMetric(s, metric, goRpcEncoding)
 }
 
 // AsTextString returns this value as a text friendly string.

--- a/go/tricorder/metric_test.go
+++ b/go/tricorder/metric_test.go
@@ -504,54 +504,40 @@ func TestAPI(t *testing.T) {
 	// Check /testargs
 	argsMetric := root.GetMetric("/testargs")
 	verifyMetric(t, "Args passed to app", units.None, argsMetric)
-	assertValueDeepEquals(
-		t,
-		&messages.Value{
-			Kind:  types.String,
-			Value: "--help"},
-		argsMetric.AsJsonValue(nil))
-	assertValueDeepEquals(
-		t,
-		&messages.Value{
-			Kind:  types.String,
-			Value: "--help"},
-		argsMetric.AsRpcValue(nil))
+	verifyJsonValue(t, argsMetric, types.String, 0, "--help")
+	verifyRpcValue(t, argsMetric, types.String, 0, "--help")
 	assertValueEquals(t, "\"--help\"", argsMetric.AsHtmlString(nil))
 
 	// Check /testname
 	nameMetric := root.GetMetric("/testname")
 	verifyMetric(t, "Name of app", units.None, nameMetric)
-	assertValueDeepEquals(
+	verifyJsonValue(
 		t,
-		&messages.Value{
-			Kind:  types.String,
-			Value: "My application"},
-		nameMetric.AsJsonValue(nil))
-	assertValueDeepEquals(
+		nameMetric, types.String, 0,
+		"My application")
+
+	verifyRpcValue(
 		t,
-		&messages.Value{
-			Kind:  types.String,
-			Value: "My application"},
-		nameMetric.AsRpcValue(nil))
+		nameMetric, types.String, 0,
+		"My application")
+
 	assertValueEquals(t, "\"My application\"", nameMetric.AsHtmlString(nil))
 
 	// Check /bytes/bytes
 	sizeInBytesMetric := root.GetMetric("/bytes/bytes")
 	verifyMetric(t, "Size in Bytes", units.Byte, sizeInBytesMetric)
-	assertValueDeepEquals(
+	verifyJsonValue(
 		t,
-		&messages.Value{
-			Kind:  types.Int,
-			Bits:  32,
-			Value: int64(934912)},
-		sizeInBytesMetric.AsJsonValue(nil))
-	assertValueDeepEquals(
+		sizeInBytesMetric, types.Int,
+		32,
+		int64(934912))
+
+	verifyRpcValue(
 		t,
-		&messages.Value{
-			Kind:  types.Int,
-			Bits:  32,
-			Value: int64(934912)},
-		sizeInBytesMetric.AsRpcValue(nil))
+		sizeInBytesMetric, types.Int,
+		32,
+		int64(934912))
+
 	assertValueEquals(
 		t, "913 KiB", sizeInBytesMetric.AsHtmlString(nil))
 	assertValueEquals(
@@ -565,20 +551,18 @@ func TestAPI(t *testing.T) {
 		"Speed in Bytes per Second",
 		units.BytePerSecond,
 		speedInBytesPerSecondMetric)
-	assertValueDeepEquals(
+	verifyJsonValue(
 		t,
-		&messages.Value{
-			Kind:  types.Uint,
-			Bits:  32,
-			Value: uint64(3538944)},
-		speedInBytesPerSecondMetric.AsJsonValue(nil))
-	assertValueDeepEquals(
+		speedInBytesPerSecondMetric, types.Uint,
+		32,
+		uint64(3538944))
+
+	verifyRpcValue(
 		t,
-		&messages.Value{
-			Kind:  types.Uint,
-			Bits:  32,
-			Value: uint64(3538944)},
-		speedInBytesPerSecondMetric.AsRpcValue(nil))
+		speedInBytesPerSecondMetric, types.Uint,
+		32,
+		uint64(3538944))
+
 	assertValueEquals(
 		t,
 		"3.38 MiB/s",
@@ -591,132 +575,113 @@ func TestAPI(t *testing.T) {
 	// Check /times/seconds
 	inSecondMetric := root.GetMetric("/times/seconds")
 	verifyMetric(t, "In seconds", units.Second, inSecondMetric)
-	assertValueDeepEquals(
+	verifyJsonValue(
 		t,
-		&messages.Value{
-			Kind:  types.Duration,
-			Value: "-21.053000000"},
-		inSecondMetric.AsJsonValue(nil))
-	assertValueDeepEquals(
+		inSecondMetric, types.Duration, 0,
+		"-21.053000000")
+
+	verifyRpcValue(
 		t,
-		&messages.Value{
-			Kind:  types.GoDuration,
-			Value: -21*time.Second - 53*time.Millisecond,
-		},
-		inSecondMetric.AsRpcValue(nil))
+		inSecondMetric, types.GoDuration, 0,
+		-21*time.Second-53*time.Millisecond)
+
 	assertValueEquals(t, "-21.053000000", inSecondMetric.AsHtmlString(nil))
 	assertValueEquals(t, "-21.053000000", inSecondMetric.AsTextString(nil))
 
 	// Check /times/milliseconds
 	inMillisecondMetric := root.GetMetric("/times/milliseconds")
 	verifyMetric(t, "In milliseconds", units.Millisecond, inMillisecondMetric)
-	assertValueDeepEquals(
+	verifyJsonValue(
 		t,
-		&messages.Value{
-			Kind:  types.Duration,
-			Value: "7008.000000"},
-		inMillisecondMetric.AsJsonValue(nil))
-	assertValueDeepEquals(
+		inMillisecondMetric, types.Duration, 0,
+		"7008.000000")
+
+	verifyRpcValue(
 		t,
-		&messages.Value{
-			Kind:  types.GoDuration,
-			Value: 7*time.Second + 8*time.Millisecond,
-		},
-		inMillisecondMetric.AsRpcValue(nil))
+		inMillisecondMetric, types.GoDuration, 0,
+		7*time.Second+8*time.Millisecond)
+
 	assertValueEquals(t, "7.008s", inMillisecondMetric.AsHtmlString(nil))
 	assertValueEquals(t, "7008.000000", inMillisecondMetric.AsTextString(nil))
 
 	// Check /proc/temperature
 	temperatureMetric := root.GetMetric("/proc/temperature")
 	verifyMetric(t, "Temperature", units.Celsius, temperatureMetric)
-	assertValueDeepEquals(
+	verifyJsonValue(
 		t,
-		&messages.Value{
-			Kind:  types.Float,
-			Bits:  64,
-			Value: 22.5},
-		temperatureMetric.AsJsonValue(nil))
-	assertValueDeepEquals(
+		temperatureMetric, types.Float,
+		64,
+		22.5)
+
+	verifyRpcValue(
 		t,
-		&messages.Value{
-			Kind:  types.Float,
-			Bits:  64,
-			Value: 22.5},
-		temperatureMetric.AsRpcValue(nil))
+		temperatureMetric, types.Float,
+		64,
+		22.5)
+
 	assertValueEquals(t, "22.5", temperatureMetric.AsHtmlString(nil))
 
 	// Check /proc/start-time
 	startTimeMetric := root.GetMetric("/proc/test-start-time")
 	verifyMetric(t, "Start Time", units.Second, startTimeMetric)
-	assertValueDeepEquals(
+	verifyJsonValue(
 		t,
-		&messages.Value{
-			Kind:  types.Int,
-			Bits:  64,
-			Value: int64(-1234567)},
-		startTimeMetric.AsJsonValue(nil))
-	assertValueDeepEquals(
+		startTimeMetric, types.Int,
+		64,
+		int64(-1234567))
+
+	verifyRpcValue(
 		t,
-		&messages.Value{
-			Kind:  types.Int,
-			Bits:  64,
-			Value: int64(-1234567)},
-		startTimeMetric.AsRpcValue(nil))
+		startTimeMetric, types.Int,
+		64,
+		int64(-1234567))
+
 	assertValueEquals(t, "-1234567", startTimeMetric.AsTextString(nil))
 	assertValueEquals(t, "-1.23 million", startTimeMetric.AsHtmlString(nil))
 
 	// Check /proc/some-time
 	someTimeMetric := root.GetMetric("/proc/some-time")
 	verifyMetric(t, "Some time", units.None, someTimeMetric)
-	assertValueDeepEquals(
+	verifyJsonValue(
 		t,
-		&messages.Value{
-			Kind:  types.Time,
-			Value: "1447594013.007265341"},
-		someTimeMetric.AsJsonValue(nil))
-	assertValueDeepEquals(
+		someTimeMetric, types.Time, 0,
+		"1447594013.007265341")
+
+	verifyRpcValue(
 		t,
-		&messages.Value{
-			Kind:  types.GoTime,
-			Value: someTime,
-		},
-		someTimeMetric.AsRpcValue(nil))
+		someTimeMetric, types.GoTime, 0,
+		someTime)
+
 	assertValueEquals(t, "2015-11-15T13:26:53.007265341Z", someTimeMetric.AsHtmlString(nil))
 
 	// Check /proc/some-time-ptr
 	someTimePtrMetric := root.GetMetric("/proc/some-time-ptr")
 	verifyMetric(t, "Some time pointer", units.None, someTimePtrMetric)
 	// a nil time pointer should result in 0 time.
-	assertValueDeepEquals(
+	verifyJsonValue(
 		t,
-		&messages.Value{
-			Kind:  types.Time,
-			Value: "0.000000000"},
-		someTimePtrMetric.AsJsonValue(nil))
-	assertValueDeepEquals(
+		someTimePtrMetric, types.Time, 0,
+		"0.000000000")
+
+	verifyRpcValue(
 		t,
-		&messages.Value{
-			Kind:  types.GoTime,
-			Value: time.Time{},
-		},
-		someTimePtrMetric.AsRpcValue(nil))
+		someTimePtrMetric, types.GoTime, 0,
+		time.Time{})
+
 	assertValueEquals(t, "0001-01-01T00:00:00Z", someTimePtrMetric.AsHtmlString(nil))
 
 	newTime := time.Date(2015, time.September, 6, 5, 26, 35, 0, time.UTC)
 	someTimePtr = &newTime
-	assertValueDeepEquals(
+	verifyJsonValue(
 		t,
-		&messages.Value{
-			Kind:  types.Time,
-			Value: "1441517195.000000000"},
-		someTimePtrMetric.AsJsonValue(nil))
-	assertValueDeepEquals(
+		someTimePtrMetric, types.Time, 0,
+		"1441517195.000000000")
+
+	verifyRpcValue(
 		t,
-		&messages.Value{
-			Kind:  types.GoTime,
-			Value: newTime,
-		},
-		someTimePtrMetric.AsRpcValue(nil))
+		someTimePtrMetric, types.GoTime, 0,
+		newTime)
+
 	assertValueEquals(
 		t,
 		"2015-09-06T05:26:35Z",
@@ -725,86 +690,79 @@ func TestAPI(t *testing.T) {
 	// Check /proc/rpc-count
 	rpcCountMetric := root.GetMetric("/proc/rpc-count")
 	verifyMetric(t, "RPC count", units.None, rpcCountMetric)
-	assertValueDeepEquals(
+	verifyJsonValue(
 		t,
-		&messages.Value{
-			Kind:  types.Uint,
-			Bits:  64,
-			Value: uint64(500)},
-		rpcCountMetric.AsJsonValue(nil))
-	assertValueDeepEquals(
+		rpcCountMetric, types.Uint,
+		64,
+		uint64(500))
+
+	verifyRpcValue(
 		t,
-		&messages.Value{
-			Kind:  types.Uint,
-			Bits:  64,
-			Value: uint64(500)},
-		rpcCountMetric.AsRpcValue(nil))
+		rpcCountMetric, types.Uint,
+		64,
+		uint64(500))
+
 	assertValueEquals(t, "500", rpcCountMetric.AsHtmlString(nil))
 
 	// check /proc/foo/bar/baz
 	bazMetric := root.GetMetric("proc/foo/bar/baz")
 	verifyMetric(t, "An error", units.None, bazMetric)
-	assertValueDeepEquals(
+	verifyJsonValue(
 		t,
-		&messages.Value{
-			Kind:  types.Float,
-			Bits:  32,
-			Value: 12.375},
-		bazMetric.AsJsonValue(nil))
-	assertValueDeepEquals(
+		bazMetric, types.Float,
+		32,
+		12.375)
+
+	verifyRpcValue(
 		t,
-		&messages.Value{
-			Kind:  types.Float,
-			Bits:  32,
-			Value: 12.375},
-		bazMetric.AsRpcValue(nil))
+		bazMetric, types.Float,
+		32,
+		12.375)
+
 	assertValueEquals(t, "12.375", bazMetric.AsHtmlString(nil))
 
 	// check /proc/foo/bar/abool
 	aboolMetric := root.GetMetric("proc/foo/bar/abool")
 	verifyMetric(t, "A boolean value", units.None, aboolMetric)
-	assertValueDeepEquals(
+	verifyJsonValue(
 		t,
-		&messages.Value{
-			Kind:  types.Bool,
-			Value: true},
-		aboolMetric.AsJsonValue(nil))
-	assertValueDeepEquals(
+		aboolMetric, types.Bool, 0,
+		true)
+
+	verifyRpcValue(
 		t,
-		&messages.Value{
-			Kind:  types.Bool,
-			Value: true},
-		aboolMetric.AsRpcValue(nil))
+		aboolMetric, types.Bool, 0,
+		true)
+
 	assertValueEquals(t, "true", aboolMetric.AsHtmlString(nil))
 
 	// check /proc/foo/bar/anotherBool
 	anotherBoolMetric := root.GetMetric("proc/foo/bar/anotherBool")
 	verifyMetric(t, "A boolean callback value", units.None, anotherBoolMetric)
-	assertValueDeepEquals(
+	verifyJsonValue(
 		t,
-		&messages.Value{
-			Kind:  types.Bool,
-			Value: false},
-		anotherBoolMetric.AsJsonValue(nil))
-	assertValueDeepEquals(
+		anotherBoolMetric, types.Bool, 0,
+		false)
+
+	verifyRpcValue(
 		t,
-		&messages.Value{
-			Kind:  types.Bool,
-			Value: false},
-		anotherBoolMetric.AsRpcValue(nil))
+		anotherBoolMetric, types.Bool, 0,
+		false)
+
 	assertValueEquals(t, "false", anotherBoolMetric.AsHtmlString(nil))
 
 	// Check /proc/rpc-latency
 	rpcLatency := root.GetMetric("/proc/rpc-latency")
 	verifyMetric(t, "RPC latency", units.Millisecond, rpcLatency)
 
-	actual := rpcLatency.AsJsonValue(nil)
+	var actual messages.Metric
+	rpcLatency.UpdateJsonMetric(nil, &actual)
 
 	if actual.Value.(*messages.Distribution).Median < 249 || actual.Value.(*messages.Distribution).Median >= 250 {
 		t.Errorf("Median out of range: %f", actual.Value.(*messages.Distribution).Median)
 	}
 
-	expected := &messages.Value{
+	expected := &messages.Metric{
 		Kind: types.Dist,
 		Value: &messages.Distribution{
 			Min:     0.0,
@@ -845,15 +803,16 @@ func TestAPI(t *testing.T) {
 			},
 		},
 	}
-	assertValueDeepEquals(t, expected, actual)
+	assertValueDeepEquals(t, expected, &actual)
 
-	actualRpc := rpcLatency.AsRpcValue(nil)
+	var actualRpc messages.Metric
+	rpcLatency.UpdateRpcMetric(nil, &actualRpc)
 
 	if actualRpc.Value.(*messages.Distribution).Median < 249 || actualRpc.Value.(*messages.Distribution).Median >= 250 {
 		t.Errorf("Median out of range in rpc: %f", actualRpc.Value.(*messages.Distribution).Median)
 	}
 
-	expectedRpc := &messages.Value{
+	expectedRpc := &messages.Metric{
 		Kind: types.Dist,
 		Value: &messages.Distribution{
 			Min:     0.0,
@@ -894,7 +853,7 @@ func TestAPI(t *testing.T) {
 			},
 		},
 	}
-	assertValueDeepEquals(t, expectedRpc, actualRpc)
+	assertValueDeepEquals(t, expectedRpc, &actualRpc)
 
 	// test PathFrom
 	assertValueEquals(
@@ -1153,6 +1112,24 @@ func assertValueDeepEquals(
 	if !reflect.DeepEqual(expected, actual) {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
+}
+
+func verifyJsonValue(
+	t *testing.T, m *metric, tp types.Type, bits int, value interface{}) {
+	var ametric messages.Metric
+	m.UpdateJsonMetric(nil, &ametric)
+	assertValueEquals(t, tp, ametric.Kind)
+	assertValueEquals(t, bits, ametric.Bits)
+	assertValueEquals(t, value, ametric.Value)
+}
+
+func verifyRpcValue(
+	t *testing.T, m *metric, tp types.Type, bits int, value interface{}) {
+	var ametric messages.Metric
+	m.UpdateRpcMetric(nil, &ametric)
+	assertValueEquals(t, tp, ametric.Kind)
+	assertValueEquals(t, bits, ametric.Bits)
+	assertValueEquals(t, value, ametric.Value)
 }
 
 func verifyChildren(

--- a/go/tricorder/rpc.go
+++ b/go/tricorder/rpc.go
@@ -6,11 +6,12 @@ import (
 )
 
 func rpcAsMetric(m *metric, s *session) *messages.Metric {
-	return &messages.Metric{
+	result := messages.Metric{
 		Path:        m.AbsPath(),
 		Description: m.Description,
-		Unit:        m.Unit(),
-		Value:       m.AsRpcValue(s)}
+		Unit:        m.Unit()}
+	m.UpdateRpcMetric(s, &result)
+	return &result
 }
 
 type rpcMetricsCollector messages.MetricList


### PR DESCRIPTION
Since we are using native time.Time and time.Duration in go RPC, there is no need to expose the messages.Duration type. So, I make it private.

Since we are storing all values in a single interface field, we don't gain anything by having a nested "Value" type in the JSON, so I make messages.Metric be flat so that the JSON will be flat.
