### PR TITLE
Push goRpc to Json conversion down into the messages package.

### DIFF
--- a/go/tricorder/messages/api.go
+++ b/go/tricorder/messages/api.go
@@ -47,6 +47,65 @@ type Distribution struct {
 	Ranges []*RangeWithCount `json:"ranges,omitempty"`
 }
 
+// Duration represents a duration of time
+// For negative durations, both Seconds and Nanoseconds are negative.
+type Duration struct {
+	Seconds     int64
+	Nanoseconds int32
+}
+
+func NewDuration(d time.Duration) Duration {
+	return newDuration(d)
+}
+
+// SinceEpoch returns the amount of time since unix epoch
+func SinceEpoch(t time.Time) Duration {
+	return sinceEpoch(t)
+}
+
+// AsGoDuration converts this duration to a go duration
+func (d Duration) AsGoDuration() time.Duration {
+	return d.asGoDuration()
+}
+
+// AsGoTime Converts this duration to a go time.
+// This is the inverse of SinceEpoch.
+func (d Duration) AsGoTime() time.Time {
+	return d.asGoTime()
+}
+
+// String shows in seconds
+func (d Duration) String() string {
+	return d.stringUsingUnits(units.Second)
+}
+
+// StringUsingUnits shows in specified time unit.
+// If unit not a time, shows in seconds.
+func (d Duration) StringUsingUnits(unit units.Unit) string {
+	return d.stringUsingUnits(unit)
+}
+
+// IsNegative returns true if this duration is negative.
+func (d Duration) IsNegative() bool {
+	return d.isNegative()
+}
+
+// PrettyFormat pretty formats this duration.
+// PrettyFormat panics if this duration is negative.
+func (d Duration) PrettyFormat() string {
+	return d.prettyFormat()
+}
+
+// Value represents the value of a metric.
+type Value struct {
+	// The value's type
+	Kind types.Type `json:"kind"`
+	// The value's size in bits if Int, Uint, or float
+	Bits int `json:"bits,omitempty"`
+	// value stored here
+	Value interface{} `json:"value"`
+}
+
 // Metric represents a single metric
 type Metric struct {
 	// The absolute path to this metric

--- a/go/tricorder/messages/api.go
+++ b/go/tricorder/messages/api.go
@@ -49,6 +49,7 @@ type Distribution struct {
 
 // Duration represents a duration of time
 // For negative durations, both Seconds and Nanoseconds are negative.
+// Internal use only for now.
 type Duration struct {
 	Seconds     int64
 	Nanoseconds int32
@@ -120,6 +121,11 @@ type Metric struct {
 	Bits int `json:"bits,omitempty"`
 	// value stored here
 	Value interface{} `json:"value"`
+}
+
+// ToJson converts this instance for Json.
+func (m *Metric) ToJson() {
+	m.toJson()
 }
 
 // MetricList represents a list of metrics.

--- a/go/tricorder/messages/duration.go
+++ b/go/tricorder/messages/duration.go
@@ -1,4 +1,4 @@
-package tricorder
+package messages
 
 import (
 	"fmt"
@@ -10,21 +10,14 @@ const (
 	oneMillion = 1000000
 )
 
-// duration represents a duration of time
-// For negative durations, both Seconds and Nanoseconds are negative.
-type duration struct {
-	Seconds     int64
-	Nanoseconds int32
-}
-
-func newDuration(d time.Duration) (result duration) {
+func newDuration(d time.Duration) (result Duration) {
 	result.Seconds = int64(d / time.Second)
 	result.Nanoseconds = int32((d % time.Second) / time.Nanosecond)
 	return
 }
 
-// sinceEpoch returns the amount of time since unix epoch
-func durationSinceEpoch(t time.Time) (result duration) {
+// SinceEpoch returns the amount of time since unix epoch
+func sinceEpoch(t time.Time) (result Duration) {
 	result.Seconds = t.Unix()
 	result.Nanoseconds = int32(t.Nanosecond())
 	if result.Seconds < 0 && result.Nanoseconds > 0 {
@@ -34,25 +27,15 @@ func durationSinceEpoch(t time.Time) (result duration) {
 	return
 }
 
-// AsGoDuration converts this duration to a go duration
-func (d duration) AsGoDuration() time.Duration {
+func (d Duration) asGoDuration() time.Duration {
 	return time.Second*time.Duration(d.Seconds) + time.Duration(d.Nanoseconds)*time.Nanosecond
 }
 
-// AsGoTime Converts this duration to a go time.
-// This is the inverse of SinceEpoch.
-func (d duration) AsGoTime() time.Time {
+func (d Duration) asGoTime() time.Time {
 	return time.Unix(d.Seconds, int64(d.Nanoseconds))
 }
 
-// String shows in seconds
-func (d duration) String() string {
-	return d.StringUsingUnits(units.Second)
-}
-
-// StringUsingUnits shows in specified time unit.
-// If unit not a time, shows in seconds.
-func (d duration) StringUsingUnits(unit units.Unit) string {
+func (d Duration) stringUsingUnits(unit units.Unit) string {
 	formattedNs := d.Nanoseconds
 	if formattedNs < 0 {
 		formattedNs = -formattedNs
@@ -70,15 +53,12 @@ func (d duration) StringUsingUnits(unit units.Unit) string {
 
 }
 
-// IsNegative returns true if this duration is negative.
-func (d duration) IsNegative() bool {
+func (d Duration) isNegative() bool {
 	return d.Nanoseconds < 0 || d.Seconds < 0
 }
 
-// PrettyFormat pretty formats this duration.
-// PrettyFormat panics if this duration is negative.
-func (d duration) PrettyFormat() string {
-	if d.IsNegative() {
+func (d Duration) prettyFormat() string {
+	if d.isNegative() {
 		panic("Cannot pretty format negative durations")
 	}
 	switch {

--- a/go/tricorder/messages/duration_test.go
+++ b/go/tricorder/messages/duration_test.go
@@ -1,4 +1,4 @@
-package tricorder
+package messages
 
 import (
 	"github.com/Symantec/tricorder/go/tricorder/units"
@@ -7,142 +7,142 @@ import (
 )
 
 func TestDuration(t *testing.T) {
-	var expected duration
+	var expected Duration
 	if expected.IsNegative() {
 		t.Error("Expected duration to be positive.")
 	}
-	var dur time.Duration
-	actual := newDuration(dur)
+	var duration time.Duration
+	actual := NewDuration(duration)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
-	if out := expected.AsGoDuration(); out != dur {
-		t.Errorf("Expected %d, got %d", dur, out)
+	if out := expected.AsGoDuration(); out != duration {
+		t.Errorf("Expected %d, got %d", duration, out)
 	}
-	expected = duration{Seconds: 0, Nanoseconds: 1}
-	dur = time.Nanosecond
-	actual = newDuration(dur)
+	expected = Duration{Seconds: 0, Nanoseconds: 1}
+	duration = time.Nanosecond
+	actual = NewDuration(duration)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
-	if out := expected.AsGoDuration(); out != dur {
-		t.Errorf("Expected %d, got %d", dur, out)
+	if out := expected.AsGoDuration(); out != duration {
+		t.Errorf("Expected %d, got %d", duration, out)
 	}
-	expected = duration{Seconds: 1, Nanoseconds: 0}
+	expected = Duration{Seconds: 1, Nanoseconds: 0}
 	if expected.IsNegative() {
 		t.Error("Expected duration to be positive.")
 	}
-	dur = time.Second
-	actual = newDuration(dur)
+	duration = time.Second
+	actual = NewDuration(duration)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
-	if out := expected.AsGoDuration(); out != dur {
-		t.Errorf("Expected %d, got %d", dur, out)
+	if out := expected.AsGoDuration(); out != duration {
+		t.Errorf("Expected %d, got %d", duration, out)
 	}
-	expected = duration{Seconds: 1, Nanoseconds: 999999999}
-	dur = 2*time.Second - time.Nanosecond
-	actual = newDuration(dur)
+	expected = Duration{Seconds: 1, Nanoseconds: 999999999}
+	duration = 2*time.Second - time.Nanosecond
+	actual = NewDuration(duration)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
-	if out := expected.AsGoDuration(); out != dur {
-		t.Errorf("Expected %d, got %d", dur, out)
+	if out := expected.AsGoDuration(); out != duration {
+		t.Errorf("Expected %d, got %d", duration, out)
 	}
-	expected = duration{Seconds: 0, Nanoseconds: -1}
+	expected = Duration{Seconds: 0, Nanoseconds: -1}
 	if !expected.IsNegative() {
 		t.Error("Expected duration to be negative.")
 	}
-	dur = -time.Nanosecond
-	actual = newDuration(dur)
+	duration = -time.Nanosecond
+	actual = NewDuration(duration)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
-	if out := expected.AsGoDuration(); out != dur {
-		t.Errorf("Expected %d, got %d", dur, out)
+	if out := expected.AsGoDuration(); out != duration {
+		t.Errorf("Expected %d, got %d", duration, out)
 	}
-	expected = duration{Seconds: -1, Nanoseconds: 0}
+	expected = Duration{Seconds: -1, Nanoseconds: 0}
 	if !expected.IsNegative() {
 		t.Error("Expected duration to be negative.")
 	}
-	dur = -time.Second
-	actual = newDuration(dur)
+	duration = -time.Second
+	actual = NewDuration(duration)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
-	if out := expected.AsGoDuration(); out != dur {
-		t.Errorf("Expected %d, got %d", dur, out)
+	if out := expected.AsGoDuration(); out != duration {
+		t.Errorf("Expected %d, got %d", duration, out)
 	}
-	expected = duration{Seconds: -1, Nanoseconds: -999999999}
-	dur = -2*time.Second + time.Nanosecond
-	actual = newDuration(dur)
+	expected = Duration{Seconds: -1, Nanoseconds: -999999999}
+	duration = -2*time.Second + time.Nanosecond
+	actual = NewDuration(duration)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
-	if out := expected.AsGoDuration(); out != dur {
-		t.Errorf("Expected %d, got %d", dur, out)
+	if out := expected.AsGoDuration(); out != duration {
+		t.Errorf("Expected %d, got %d", duration, out)
 	}
 }
 
 func TestTime(t *testing.T) {
 	epoch := time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC)
-	var expected duration
+	var expected Duration
 	tm := epoch
-	actual := durationSinceEpoch(tm)
+	actual := SinceEpoch(tm)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
 	if out := expected.AsGoTime().UTC(); out != tm {
 		t.Errorf("Expected %d, got %d", tm, out)
 	}
-	expected = duration{Seconds: 0, Nanoseconds: 1}
+	expected = Duration{Seconds: 0, Nanoseconds: 1}
 	tm = epoch.Add(time.Nanosecond)
-	actual = durationSinceEpoch(tm)
+	actual = SinceEpoch(tm)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
 	if out := expected.AsGoTime().UTC(); out != tm {
 		t.Errorf("Expected %d, got %d", tm, out)
 	}
-	expected = duration{Seconds: 1, Nanoseconds: 0}
+	expected = Duration{Seconds: 1, Nanoseconds: 0}
 	tm = epoch.Add(time.Second)
-	actual = durationSinceEpoch(tm)
+	actual = SinceEpoch(tm)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
 	if out := expected.AsGoTime().UTC(); out != tm {
 		t.Errorf("Expected %d, got %d", tm, out)
 	}
-	expected = duration{Seconds: 1, Nanoseconds: 999999999}
+	expected = Duration{Seconds: 1, Nanoseconds: 999999999}
 	tm = epoch.Add(2*time.Second - time.Nanosecond)
-	actual = durationSinceEpoch(tm)
+	actual = SinceEpoch(tm)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
 	if out := expected.AsGoTime().UTC(); out != tm {
 		t.Errorf("Expected %d, got %d", tm, out)
 	}
-	expected = duration{Seconds: 0, Nanoseconds: -1}
+	expected = Duration{Seconds: 0, Nanoseconds: -1}
 	tm = epoch.Add(-time.Nanosecond)
-	actual = durationSinceEpoch(tm)
+	actual = SinceEpoch(tm)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
 	if out := expected.AsGoTime().UTC(); out != tm {
 		t.Errorf("Expected %d, got %d", tm, out)
 	}
-	expected = duration{Seconds: -1, Nanoseconds: 0}
+	expected = Duration{Seconds: -1, Nanoseconds: 0}
 	tm = epoch.Add(-time.Second)
-	actual = durationSinceEpoch(tm)
+	actual = SinceEpoch(tm)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
 	if out := expected.AsGoTime().UTC(); out != tm {
 		t.Errorf("Expected %d, got %d", tm, out)
 	}
-	expected = duration{Seconds: -1, Nanoseconds: -999999999}
+	expected = Duration{Seconds: -1, Nanoseconds: -999999999}
 	tm = epoch.Add(-2*time.Second + time.Nanosecond)
-	actual = durationSinceEpoch(tm)
+	actual = SinceEpoch(tm)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
@@ -152,59 +152,59 @@ func TestTime(t *testing.T) {
 }
 
 func TestString(t *testing.T) {
-	dur := duration{Seconds: 57}
+	dur := Duration{Seconds: 57}
 	if out := dur.String(); out != "57.000000000" {
 		t.Errorf("Expected 57.000000000, got %s", out)
 	}
-	dur = duration{Seconds: -53, Nanoseconds: -200000000}
+	dur = Duration{Seconds: -53, Nanoseconds: -200000000}
 	if out := dur.String(); out != "-53.200000000" {
 		t.Errorf("Expected -53.200000000, got %s", out)
 	}
 	if out := dur.StringUsingUnits(units.Millisecond); out != "-53200.000000" {
 		t.Errorf("Expected -53200.000000, got %s", out)
 	}
-	dur = duration{Seconds: 53, Nanoseconds: 123456789}
+	dur = Duration{Seconds: 53, Nanoseconds: 123456789}
 	if out := dur.StringUsingUnits(units.Millisecond); out != "53123.456789" {
 		t.Errorf("Expected 53123.456789, got %s", out)
 	}
 }
 
 func TestPrettyFormat(t *testing.T) {
-	var dur duration
+	var dur Duration
 	assertStringEquals(t, "0ns", dur.PrettyFormat())
-	dur = duration{Nanoseconds: 7}
+	dur = Duration{Nanoseconds: 7}
 	assertStringEquals(t, "7ns", dur.PrettyFormat())
-	dur = duration{Nanoseconds: 9999}
+	dur = Duration{Nanoseconds: 9999}
 	assertStringEquals(t, "9999ns", dur.PrettyFormat())
-	dur = duration{Nanoseconds: 10000}
+	dur = Duration{Nanoseconds: 10000}
 	assertStringEquals(t, "10μs", dur.PrettyFormat())
-	dur = duration{Nanoseconds: 13789}
+	dur = Duration{Nanoseconds: 13789}
 	assertStringEquals(t, "13μs", dur.PrettyFormat())
-	dur = duration{Nanoseconds: 9999999}
+	dur = Duration{Nanoseconds: 9999999}
 	assertStringEquals(t, "9999μs", dur.PrettyFormat())
-	dur = duration{Nanoseconds: 10000000}
+	dur = Duration{Nanoseconds: 10000000}
 	assertStringEquals(t, "10ms", dur.PrettyFormat())
-	dur = duration{Nanoseconds: 678000000}
+	dur = Duration{Nanoseconds: 678000000}
 	assertStringEquals(t, "678ms", dur.PrettyFormat())
-	dur = duration{Nanoseconds: 999000000}
+	dur = Duration{Nanoseconds: 999000000}
 	assertStringEquals(t, "999ms", dur.PrettyFormat())
-	dur = duration{Seconds: 1}
+	dur = Duration{Seconds: 1}
 	assertStringEquals(t, "1.000s", dur.PrettyFormat())
-	dur = duration{Seconds: 35, Nanoseconds: 871000000}
+	dur = Duration{Seconds: 35, Nanoseconds: 871000000}
 	assertStringEquals(t, "35.871s", dur.PrettyFormat())
-	dur = duration{Seconds: 59, Nanoseconds: 999000000}
+	dur = Duration{Seconds: 59, Nanoseconds: 999000000}
 	assertStringEquals(t, "59.999s", dur.PrettyFormat())
-	dur = duration{Seconds: 60}
+	dur = Duration{Seconds: 60}
 	assertStringEquals(t, "1m 0.000s", dur.PrettyFormat())
-	dur = duration{Seconds: 3541, Nanoseconds: 10000000}
+	dur = Duration{Seconds: 3541, Nanoseconds: 10000000}
 	assertStringEquals(t, "59m 1.010s", dur.PrettyFormat())
-	dur = duration{Seconds: 3600}
+	dur = Duration{Seconds: 3600}
 	assertStringEquals(t, "1h 0m 0s", dur.PrettyFormat())
-	dur = duration{Seconds: 83000}
+	dur = Duration{Seconds: 83000}
 	assertStringEquals(t, "23h 3m 20s", dur.PrettyFormat())
-	dur = duration{Seconds: 86400}
+	dur = Duration{Seconds: 86400}
 	assertStringEquals(t, "1d 0h 0m 0s", dur.PrettyFormat())
-	dur = duration{Seconds: 200000}
+	dur = Duration{Seconds: 200000}
 	assertStringEquals(t, "2d 7h 33m 20s", dur.PrettyFormat())
 }
 

--- a/go/tricorder/messages/metric.go
+++ b/go/tricorder/messages/metric.go
@@ -1,0 +1,29 @@
+package messages
+
+import (
+	"github.com/Symantec/tricorder/go/tricorder/types"
+	"time"
+)
+
+func (m *Metric) toJson() {
+	switch m.Kind {
+	case types.GoDuration:
+		m.Kind = types.Duration
+		m.Value = m.durationAsString(m.Value.(time.Duration))
+	case types.GoTime:
+		m.Kind = types.Time
+		m.Value = m.timeAsString(m.Value.(time.Time))
+	}
+}
+
+func (m *Metric) durationAsString(godur time.Duration) string {
+	return NewDuration(godur).StringUsingUnits(m.Unit)
+}
+
+func (m *Metric) timeAsString(gotime time.Time) string {
+	var dur Duration
+	if !gotime.IsZero() {
+		dur = SinceEpoch(gotime)
+	}
+	return dur.StringUsingUnits(m.Unit)
+}

--- a/go/tricorder/metric.go
+++ b/go/tricorder/metric.go
@@ -616,27 +616,11 @@ func (v *value) updateJsonOrRpcMetric(
 		metric.Kind = t
 		metric.Value = v.AsString(s)
 	case types.Time:
-		switch encoding {
-		case jsonEncoding:
-			metric.Kind = t
-			metric.Value = v.AsTextString(s)
-		case goRpcEncoding:
-			metric.Kind = types.GoTime
-			metric.Value = v.AsTime(s)
-		default:
-			panic(panicIncompatibleTypes)
-		}
+		metric.Kind = types.GoTime
+		metric.Value = v.AsTime(s)
 	case types.Duration:
-		switch encoding {
-		case jsonEncoding:
-			metric.Kind = t
-			metric.Value = v.AsTextString(s)
-		case goRpcEncoding:
-			metric.Kind = types.GoDuration
-			metric.Value = v.AsGoDuration(s)
-		default:
-			panic(panicIncompatibleTypes)
-		}
+		metric.Kind = types.GoDuration
+		metric.Value = v.AsGoDuration(s)
 	case types.Dist:
 		snapshot := v.AsDistribution().Snapshot()
 		metric.Kind = t
@@ -650,6 +634,9 @@ func (v *value) updateJsonOrRpcMetric(
 			Ranges:  asRanges(snapshot.Breakdown)}
 	default:
 		panic(panicIncompatibleTypes)
+	}
+	if encoding == jsonEncoding {
+		metric.ToJson()
 	}
 }
 

--- a/go/tricorder/metric.go
+++ b/go/tricorder/metric.go
@@ -570,16 +570,16 @@ func (v *value) AsGoDuration(s *session) time.Duration {
 	return time.Duration(v.evaluate(s).Int())
 }
 
-func (v *value) AsDuration(s *session) (result duration) {
+func (v *value) AsDuration(s *session) (result messages.Duration) {
 	if v.valType == types.Time {
 		t := v.AsTime(s)
 		if t.IsZero() {
 			return
 		}
-		return durationSinceEpoch(t)
+		return messages.SinceEpoch(t)
 	}
 	if v.valType == types.Duration {
-		return newDuration(v.AsGoDuration(s))
+		return messages.NewDuration(v.AsGoDuration(s))
 	}
 	panic(panicIncompatibleTypes)
 }

--- a/go/tricorder/metric_test.go
+++ b/go/tricorder/metric_test.go
@@ -1117,6 +1117,7 @@ func assertValueDeepEquals(
 func verifyJsonValue(
 	t *testing.T, m *metric, tp types.Type, bits int, value interface{}) {
 	var ametric messages.Metric
+	ametric.Unit = m.Unit()
 	m.UpdateJsonMetric(nil, &ametric)
 	assertValueEquals(t, tp, ametric.Kind)
 	assertValueEquals(t, bits, ametric.Bits)


### PR DESCRIPTION
The collector has to convert Go times and durations to strings in order to present the metrics in Json for the dashboard UI to be written in Javascript. Converting times and durations in GoRPC to strings for Json is non-trivial because we have to honor units. The code that does this is already in the tricorder package but is not visible to externally.

To avoid code duplication, I want to push the conversion code from Go RPC to JSON down into the messages package.  Code having to do with the conversion of messages for RPC should go in the messages package rather in the tricorder package which is used to register metrics.

To accomplish this I had to revert the pull request I sent earlier to make messages.Duration be private.
