### PR TITLE
Duration as float

### DIFF
--- a/go/tricorder/messages/api.go
+++ b/go/tricorder/messages/api.go
@@ -74,8 +74,8 @@ func (d Duration) AsGoDuration() time.Duration {
 	return d.asGoDuration()
 }
 
-// AsGoTime Converts this duration to a go time.
-// This is the inverse of SinceEpoch.
+// AsGoTime Converts this duration to a go time in the
+// system's local time zone.
 func (d Duration) AsGoTime() time.Time {
 	return d.asGoTime()
 }
@@ -160,6 +160,17 @@ type MetricList []*Metric
 // AsJson returns a MetricList like this one that is Json compatible.
 func (m MetricList) AsJson() MetricList {
 	return m.asJson()
+}
+
+// FloatToTime converts seconds after Jan 1, 1970 GMT to a time in the
+// system's local time zone.
+func FloatToTime(secondsSinceEpoch float64) time.Time {
+	return SinceEpochFloat(secondsSinceEpoch).AsGoTime()
+}
+
+// TimeToFloat returns t as seconds after Jan 1, 1970 GMT
+func TimeToFloat(t time.Time) float64 {
+	return SinceEpoch(t).AsFloat()
 }
 
 func init() {

--- a/go/tricorder/messages/api.go
+++ b/go/tricorder/messages/api.go
@@ -64,6 +64,11 @@ func SinceEpoch(t time.Time) Duration {
 	return sinceEpoch(t)
 }
 
+// SinceEpochFloat returns the amount of time since unix epoch
+func SinceEpochFloat(f float64) Duration {
+	return sinceEpochFloat(f)
+}
+
 // AsGoDuration converts this duration to a go duration
 func (d Duration) AsGoDuration() time.Duration {
 	return d.asGoDuration()
@@ -73,6 +78,11 @@ func (d Duration) AsGoDuration() time.Duration {
 // This is the inverse of SinceEpoch.
 func (d Duration) AsGoTime() time.Time {
 	return d.asGoTime()
+}
+
+// AsFloat returns this duration in seconds.
+func (d Duration) AsFloat() float64 {
+	return d.asFloat()
 }
 
 // String shows in seconds

--- a/go/tricorder/messages/duration.go
+++ b/go/tricorder/messages/duration.go
@@ -3,6 +3,7 @@ package messages
 import (
 	"fmt"
 	"github.com/Symantec/tricorder/go/tricorder/units"
+	"math"
 	"time"
 )
 
@@ -24,6 +25,13 @@ func sinceEpoch(t time.Time) (result Duration) {
 		result.Seconds++
 		result.Nanoseconds -= 1000000000 // 1 billion
 	}
+	return
+}
+
+func sinceEpochFloat(f float64) (result Duration) {
+	ii, ff := math.Modf(f)
+	result.Seconds = int64(ii)
+	result.Nanoseconds = int32(ff * 1e9)
 	return
 }
 
@@ -51,6 +59,10 @@ func (d Duration) stringUsingUnits(unit units.Unit) string {
 		return fmt.Sprintf("%d.%09d", d.Seconds, formattedNs)
 	}
 
+}
+
+func (d Duration) asFloat() float64 {
+	return float64(d.Seconds) + float64(d.Nanoseconds)*1e-9
 }
 
 func (d Duration) isNegative() bool {


### PR DESCRIPTION
Add code to convert go time to seconds since epoch as float and vice versa.

I store times as floats in my in memory datastore. Each float64 uses only 8 bytes of memory compared with the 20 bytes of memory that time.Time uses. This means that each metric record can fit into just 48 bytes instead of 64 bytes.  This means we can store 33% more metrics with the same amount of RAM.

The floats give us millisecond precision up to 300,000 years into the future.
