### PR TITLE
Allow callback functions to be registered with regions.

### DIFF
--- a/go/tricorder/api.go
+++ b/go/tricorder/api.go
@@ -48,9 +48,9 @@ func RegisterMetric(
 }
 
 // RegisterMetricWithRegion works just like RegisterMetrics but allows
-// the caller to specify the region to which the variable being registered
-// belongs. RegisterMetricWithRegion ignores the region parameter when
-// registering a callback function or distribution.
+// the caller to specify the region to which the variable or callback function
+// being registered belongs. RegisterMetricWithRegion ignores the region
+// parameter when registering a distribution.
 func RegisterMetricInRegion(
 	path string,
 	metric interface{},

--- a/go/tricorder/metric.go
+++ b/go/tricorder/metric.go
@@ -465,6 +465,7 @@ func newValue(spec interface{}, region *region, unit units.Unit) *value {
 		return &value{
 			val:           v,
 			unit:          unit,
+			region:        region,
 			valType:       valType,
 			bits:          bits,
 			isfunc:        true,
@@ -498,14 +499,14 @@ func (v *value) Bits() int {
 }
 
 func (v *value) evaluate(s *session) reflect.Value {
-	if !v.isfunc {
-		if v.region != nil {
-			if s == nil {
-				s = newSession()
-				defer s.Close()
-			}
-			s.Visit(v.region)
+	if v.region != nil {
+		if s == nil {
+			s = newSession()
+			defer s.Close()
 		}
+		s.Visit(v.region)
+	}
+	if !v.isfunc {
 		return v.val
 	}
 	result := v.val.Call(nil)

--- a/go/tricorder/metric_test.go
+++ b/go/tricorder/metric_test.go
@@ -52,6 +52,14 @@ func registerMetricsForGlobalsTest() {
 	RegisterMetricInRegion(
 		"/firstGroup/second", &secondGlobal, r1and2, units.None, "")
 	RegisterMetricInRegion(
+		"/firstGroup/firstTimesSecond",
+		func() int {
+			return firstGlobal * secondGlobal
+		},
+		r1and2,
+		units.None,
+		"")
+	RegisterMetricInRegion(
 		"/firstGroup/third", &thirdGlobal, r3to6, units.None, "")
 	RegisterMetricInRegion(
 		"/firstGroup/fourth", &fourthGlobal, r3to6, units.None, "")
@@ -99,9 +107,8 @@ func doGlobalsTest(t *testing.T) {
 
 	assertValueEquals(
 		t,
-		int64(202),
-		root.GetMetric("/firstGroup/second").AsInt(nil))
-
+		int64(20604),
+		root.GetMetric("/firstGroup/firstTimesSecond").AsInt(nil))
 	assertValueEquals(
 		t,
 		int64(301),
@@ -133,10 +140,9 @@ func doGlobalsTest(t *testing.T) {
 	barrier.Add(2)
 
 	// Collect metric in two goroutines running concurrently.
-	// Because the collections run concurrently, each region's update
-	// function gets called only one time even though they both collect
-	// from region r3to6.
-
+	// Because the collections run concurrently, each region's,
+	// including r3to6, update function gets called only one time even
+	// though both goroutines collect from region r3to6.
 	wg.Add(2)
 	go func() {
 		root.GetAllMetricsByPath(
@@ -150,10 +156,11 @@ func doGlobalsTest(t *testing.T) {
 	}()
 	wg.Wait()
 	expectedFirstGroup := map[string]int64{
-		"/firstGroup/first":  103,
-		"/firstGroup/second": 203,
-		"/firstGroup/third":  303,
-		"/firstGroup/fourth": 403,
+		"/firstGroup/first":            103,
+		"/firstGroup/second":           203,
+		"/firstGroup/firstTimesSecond": 20909,
+		"/firstGroup/third":            303,
+		"/firstGroup/fourth":           403,
 	}
 	expectedSecondGroup := map[string]int64{
 		"/secondGroup/fifth":   503,
@@ -199,10 +206,11 @@ func doGlobalsTest(t *testing.T) {
 	}()
 	wg.Wait()
 	expectedFirstGroupSeq := map[string]int64{
-		"/firstGroup/first":  104,
-		"/firstGroup/second": 204,
-		"/firstGroup/third":  304,
-		"/firstGroup/fourth": 404,
+		"/firstGroup/first":            104,
+		"/firstGroup/second":           204,
+		"/firstGroup/firstTimesSecond": 21216,
+		"/firstGroup/third":            304,
+		"/firstGroup/fourth":           404,
 	}
 	expectedSecondGroupSeq := map[string]int64{
 		"/secondGroup/fifth":   505,


### PR DESCRIPTION
Often I want to expose a metric that is a function of two or more fields from  an expensive system call.

While I can store the result of such a function to a designated variable in the region's updated function, it would be nice to simply register an anonymous function on the spot and know that tricorder will do the right thing.
