### PR TITLE
Add messages.DurationToFloat. Add units.FromSeconds.

### DIFF
--- a/go/tricorder/messages/api.go
+++ b/go/tricorder/messages/api.go
@@ -173,6 +173,11 @@ func TimeToFloat(t time.Time) float64 {
 	return SinceEpoch(t).AsFloat()
 }
 
+// DurationToFloat returns d as seconds
+func DurationToFloat(d time.Duration) float64 {
+	return NewDuration(d).AsFloat()
+}
+
 func init() {
 	var tm time.Time
 	var dur time.Duration

--- a/go/tricorder/units/api.go
+++ b/go/tricorder/units/api.go
@@ -12,3 +12,15 @@ const (
 	Byte          Unit = "Bytes"
 	BytePerSecond Unit = "BytesPerSecond"
 )
+
+// Returns the conversion factor between seconds and u.
+// For example FromSeconds(Millisecond) returns 1000.
+// Returns 1.0 if u is not a time unit.
+func FromSeconds(u Unit) float64 {
+	switch u {
+	case Millisecond:
+		return 1000.0
+	default:
+		return 1.0
+	}
+}


### PR DESCRIPTION
Sorry, got one more pull request. I need this to emit duration metrics as floats to LMM. 
