### PR TITLE
Add global messages.IsJson() and messages.AsJson()

### DIFF
--- a/go/tricorder/messages/api.go
+++ b/go/tricorder/messages/api.go
@@ -144,12 +144,12 @@ type Metric struct {
 
 // IsJson returns true if this metric is json compatible
 func (m *Metric) IsJson() bool {
-	return m.isJson(false)
+	return isJson(m.Kind)
 }
 
 // ConvertToJson changes this metric in place to be json compatible.
 func (m *Metric) ConvertToJson() {
-	m.isJson(true)
+	m.convertToJson()
 }
 
 // MetricList represents a list of metrics. Clients should treat MetricList
@@ -176,6 +176,18 @@ func TimeToFloat(t time.Time) float64 {
 // DurationToFloat returns d as seconds
 func DurationToFloat(d time.Duration) float64 {
 	return NewDuration(d).AsFloat()
+}
+
+// IsJson returns true if kind is allowed in Json.
+func IsJson(kind types.Type) bool {
+	return isJson(kind)
+}
+
+// AsJson takes a metric value, kind, and unit and returns an acceptable
+// JSON value and kind for given unit.
+func AsJson(value interface{}, kind types.Type, unit units.Unit) (
+	jsonValue interface{}, jsonKind types.Type) {
+	return asJson(value, kind, unit)
 }
 
 func init() {

--- a/go/tricorder/messages/metric_test.go
+++ b/go/tricorder/messages/metric_test.go
@@ -1,0 +1,18 @@
+package messages
+
+import (
+	"github.com/Symantec/tricorder/go/tricorder/types"
+	"testing"
+)
+
+func TestIsJson2(t *testing.T) {
+	if IsJson(types.GoDuration) {
+		t.Error("GoDuration is not json compatible")
+	}
+	if IsJson(types.GoTime) {
+		t.Error("GoTime is not json compatible")
+	}
+	if !IsJson(types.Int) {
+		t.Error("Int is json compatible")
+	}
+}


### PR DESCRIPTION
Again, I am not changing any existing API. I am just adding new API for scotty.

In particular, I want to avoid rewriting all the logic that converts go times and durations into strings for Json. The existing methods on messages.Metric, IsJson and ConvertToJson can't be reused on scotty because scotty has its own JSON data structures. 

So, I expose the more general messages.IsJson and messages.AsJson so that scotty can reuse.
