### PR TITLE
Fix to allow compile on linux_386.

### DIFF
--- a/go/tricorder/setup.go
+++ b/go/tricorder/setup.go
@@ -37,7 +37,7 @@ func initDefaultMetrics() {
 		syscall.Getrusage(syscall.RUSAGE_SELF, &resourceUsage)
 		userTime = timeValToDuration(&resourceUsage.Utime)
 		sysTime = timeValToDuration(&resourceUsage.Stime)
-		maxResidentSetSize = resourceUsage.Maxrss * 1024
+		maxResidentSetSize = int64(resourceUsage.Maxrss) * 1024
 	})
 	RegisterMetricInRegion(
 		"/proc/cpu/user",


### PR DESCRIPTION
On linux_386 syscall.Rusage uses int32 for it's fields whereas on linux_amd64 those fields are 64-bit, and go/tricorder/setup.go code assigns Rusage.Maxrss to an int64 variable. Adding a typecast is a quick fix.

I recall that for Darwin the units are in Bytes while for Linux the units are in KiB, so currently we get the wrong numbers for Darwin. I think we should create a platform-specific wrapper for syscall.Getrusage() to handle this.
