### PR TITLE
Introduce Update() method on tricorder.Distribution

### DIFF
--- a/go/tricorder/api.go
+++ b/go/tricorder/api.go
@@ -131,6 +131,17 @@ func (d *Distribution) Add(value interface{}) {
 	(*distribution)(d).Add(value)
 }
 
+// Update updates a value in this distribution instance.
+// value can be a float32, float64, or a time.Duration.
+// If a time.Duration, Add converts it to the same unit of time specified in
+// the RegisterMetric call made to register this Distribution.
+// Update updates all distribution statistics except min and max.
+// When a client uses Update, they accept that min and max become all time
+// min and all time max.
+func (d *Distribution) Update(oldValue, newValue interface{}) {
+	(*distribution)(d).Update(oldValue, newValue)
+}
+
 // DirectorySpec represents a specific directory in the heirarchy of
 // metrics.
 type DirectorySpec directory

--- a/go/tricorder/api.go
+++ b/go/tricorder/api.go
@@ -142,6 +142,11 @@ func (d *Distribution) Update(oldValue, newValue interface{}) {
 	(*distribution)(d).Update(oldValue, newValue)
 }
 
+// Sum returns the sum of the values in this distribution.
+func (d *Distribution) Sum() float64 {
+	return (*distribution)(d).Sum()
+}
+
 // DirectorySpec represents a specific directory in the heirarchy of
 // metrics.
 type DirectorySpec directory

--- a/go/tricorder/metric.go
+++ b/go/tricorder/metric.go
@@ -257,6 +257,12 @@ type distribution struct {
 	count  uint64
 }
 
+func (d *distribution) Sum() float64 {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	return d.total
+}
+
 func newDistribution(bucketer *Bucketer) *distribution {
 	return &distribution{
 		pieces: bucketer.pieces,

--- a/go/tricorder/metric_test.go
+++ b/go/tricorder/metric_test.go
@@ -996,7 +996,7 @@ func TestArbitraryDistribution(t *testing.T) {
 		dist.Add(float64(i))
 	}
 	actual := dist.Snapshot()
-	if actual.Median < 50.0 || actual.Median >= 51 {
+	if actual.Median < 49.5 || actual.Median >= 51.5 {
 		t.Errorf("Median out of range: %f", actual.Median)
 	}
 	expected := &snapshot{

--- a/go/tricorder/metric_test.go
+++ b/go/tricorder/metric_test.go
@@ -993,9 +993,16 @@ func TestArbitraryDistribution(t *testing.T) {
 	verifyBucketer(t, bucketer, 10.0, 22.0, 50.0)
 	dist := newDistribution(bucketer)
 	for i := 100; i >= 1; i-- {
-		dist.Add(float64(i))
+		dist.Add(100.0)
 	}
 	actual := dist.Snapshot()
+	if actual.Median != 100.0 {
+		t.Errorf("Expected median to be 100: %f", actual.Median)
+	}
+	for i := 100; i >= 1; i-- {
+		dist.Update(100.0, float64(i))
+	}
+	actual = dist.Snapshot()
 	if actual.Median < 49.5 || actual.Median >= 51.5 {
 		t.Errorf("Median out of range: %f", actual.Median)
 	}


### PR DESCRIPTION
I expose pages per metric as a distribution. However, the number of pages each metric has is constantly changing. Whenever the number of pages in a metric decreases or increases, I need a way to update an existing value in a distribution rather than adding a brand new value. Enter the Update() method.

The one caveat with the Update() is that once it is used, min and max become all time min and all time max. This is to keep distributions relatively cheap.
