### PR TITLE
Deprecate Distribution in favor of CumulativeDistribution.

### DIFF
--- a/go/tricorder/messages/api.go
+++ b/go/tricorder/messages/api.go
@@ -43,6 +43,9 @@ type Distribution struct {
 	Sum float64 `json:"sum"`
 	// The total number of values
 	Count uint64 `json:"count"`
+	// This field is incremented by 1 each time this distribution changes
+	// This distribution is cumulative iff Count == Generation.
+	Generation uint64 `json:"generation"`
 	// The number of values within each range
 	Ranges []*RangeWithCount `json:"ranges,omitempty"`
 }

--- a/go/tricorder/metric_test.go
+++ b/go/tricorder/metric_test.go
@@ -253,7 +253,7 @@ func TestAPI(t *testing.T) {
 	var speedInBytesPerSecond uint32
 
 	rpcBucketer := NewExponentialBucketer(6, 10, 2.5)
-	rpcDistribution := rpcBucketer.NewDistribution()
+	rpcDistribution := rpcBucketer.NewCumulativeDistribution()
 
 	if err := RegisterMetric(
 		"/bytes/bytes",
@@ -844,12 +844,13 @@ func TestAPI(t *testing.T) {
 	expected := &messages.Metric{
 		Kind: types.Dist,
 		Value: &messages.Distribution{
-			Min:     0.0,
-			Max:     499.0,
-			Average: 249.5,
-			Sum:     124750.0,
-			Median:  actual.Value.(*messages.Distribution).Median,
-			Count:   500,
+			Min:        0.0,
+			Max:        499.0,
+			Average:    249.5,
+			Sum:        124750.0,
+			Median:     actual.Value.(*messages.Distribution).Median,
+			Count:      500,
+			Generation: 500,
 			Ranges: []*messages.RangeWithCount{
 				{
 					Upper: 10.0,
@@ -894,12 +895,13 @@ func TestAPI(t *testing.T) {
 	expectedRpc := &messages.Metric{
 		Kind: types.Dist,
 		Value: &messages.Distribution{
-			Min:     0.0,
-			Max:     499.0,
-			Average: 249.5,
-			Sum:     124750.0,
-			Median:  actualRpc.Value.(*messages.Distribution).Median,
-			Count:   500,
+			Min:        0.0,
+			Max:        499.0,
+			Average:    249.5,
+			Sum:        124750.0,
+			Median:     actualRpc.Value.(*messages.Distribution).Median,
+			Count:      500,
+			Generation: 500,
 			Ranges: []*messages.RangeWithCount{
 				{
 					Upper: 10.0,
@@ -1004,9 +1006,10 @@ func TestArbitraryDistribution(t *testing.T) {
 		Max:     100.0,
 		Average: 50.5,
 		// Let exact matching pass
-		Median: actual.Median,
-		Sum:    5050.0,
-		Count:  100,
+		Median:     actual.Median,
+		Sum:        5050.0,
+		Count:      100,
+		Generation: 100,
 		Breakdown: breakdown{
 			{
 				bucketPiece: &bucketPiece{

--- a/go/tricorderdemo/tricorderdemo.go
+++ b/go/tricorderdemo/tricorderdemo.go
@@ -13,7 +13,7 @@ func registerMetrics() {
 	var temperature float64
 	var someBool bool
 
-	rpcDistribution := tricorder.PowersOfTen.NewDistribution()
+	rpcDistribution := tricorder.PowersOfTen.NewCumulativeDistribution()
 
 	if err := tricorder.RegisterMetric(
 		"/proc/rpc-latency",


### PR DESCRIPTION
This change also includes:
1. Introduce Generation Count in JSON and GoRPC
2. Distribution is cumulative iff Count == GenerationCount.

Cumulative distributions start with Generation = Count = 0. Other distributions
start with Count = 0 and Generation = 1 and ensure that Generation >
Count.
