### PR TITLE
Deprecate Distribution in favor of CumulativeDistribution.

### DIFF
--- a/go/tricorder/api.go
+++ b/go/tricorder/api.go
@@ -60,7 +60,9 @@ func RegisterMetricInRegion(
 	return root.registerMetric(newPathSpec(path), metric, (*region)(r), unit, description)
 }
 
-// Bucketer represents the organization of values into buckets.
+// Bucketer represents the organization of values into buckets for
+// distributions. Bucketer instances are immutable.
+
 type Bucketer struct {
 	pieces []*bucketPiece
 }

--- a/go/tricorder/messages/api.go
+++ b/go/tricorder/messages/api.go
@@ -43,6 +43,10 @@ type Distribution struct {
 	Sum float64 `json:"sum"`
 	// The total number of values
 	Count uint64 `json:"count"`
+	// This field is incremented by 1 each time this distribution changes.
+	Generation uint64 `json:"generation"`
+	// This field is true if this distribution is not cumulative.
+	IsNotCumulative bool `json:"isNotCumulative,omitempty"`
 	// The number of values within each range
 	Ranges []*RangeWithCount `json:"ranges,omitempty"`
 }

--- a/go/tricorder/metric.go
+++ b/go/tricorder/metric.go
@@ -234,27 +234,31 @@ type breakdown []breakdownPiece
 
 // snapshot represents a snapshot of a distribution
 type snapshot struct {
-	Min       float64
-	Max       float64
-	Average   float64
-	Median    float64
-	Sum       float64
-	Count     uint64
-	Breakdown breakdown
+	Min             float64
+	Max             float64
+	Average         float64
+	Median          float64
+	Sum             float64
+	Count           uint64
+	Generation      uint64
+	IsNotCumulative bool
+	Breakdown       breakdown
 }
 
 // distribution represents a distribution of values same as Distribution
 type distribution struct {
 	// Protects all fields except pieces whose contents never changes
 	// and unit which never changes after RegisterMetric sets it.
-	lock   sync.RWMutex
-	pieces []*bucketPiece
-	unit   units.Unit
-	counts []uint64
-	total  float64
-	min    float64
-	max    float64
-	count  uint64
+	lock            sync.RWMutex
+	pieces          []*bucketPiece
+	unit            units.Unit
+	counts          []uint64
+	total           float64
+	min             float64
+	max             float64
+	count           uint64
+	generation      uint64
+	isNotCumulative bool
 }
 
 func newDistribution(bucketer *Bucketer) *distribution {
@@ -294,6 +298,7 @@ func (d *distribution) add(value float64) {
 		d.max = value
 	}
 	d.count++
+	d.generation++
 }
 
 func (d *distribution) goDurationToFloat(dur time.Duration) float64 {
@@ -367,13 +372,15 @@ func (d *distribution) Snapshot() *snapshot {
 		}
 	}
 	return &snapshot{
-		Min:       d.min,
-		Max:       d.max,
-		Average:   d.total / float64(d.count),
-		Median:    d.calculateMedian(),
-		Sum:       d.total,
-		Count:     d.count,
-		Breakdown: bdn,
+		Min:             d.min,
+		Max:             d.max,
+		Average:         d.total / float64(d.count),
+		Median:          d.calculateMedian(),
+		Sum:             d.total,
+		Count:           d.count,
+		Generation:      d.generation,
+		IsNotCumulative: d.isNotCumulative,
+		Breakdown:       bdn,
 	}
 
 }
@@ -459,6 +466,12 @@ func mustGetPrimitiveType(t reflect.Type) (
 // unit parameter only used if spec is a *Distribution
 // In that case, it sets the unit of the *Distribution in place.
 func newValue(spec interface{}, region *region, unit units.Unit) *value {
+	capCumDist, ok := spec.(*CumulativeDistribution)
+	if ok {
+		dist := (*distribution)(capCumDist)
+		dist.unit = unit
+		return &value{dist: dist, unit: unit, valType: types.Dist}
+	}
 	capDist, ok := spec.(*Distribution)
 	if ok {
 		dist := (*distribution)(capDist)
@@ -669,13 +682,15 @@ func (v *value) updateJsonOrRpcMetric(
 		snapshot := v.AsDistribution().Snapshot()
 		metric.Kind = t
 		metric.Value = &messages.Distribution{
-			Min:     snapshot.Min,
-			Max:     snapshot.Max,
-			Average: snapshot.Average,
-			Median:  snapshot.Median,
-			Sum:     snapshot.Sum,
-			Count:   snapshot.Count,
-			Ranges:  asRanges(snapshot.Breakdown)}
+			Min:             snapshot.Min,
+			Max:             snapshot.Max,
+			Average:         snapshot.Average,
+			Median:          snapshot.Median,
+			Sum:             snapshot.Sum,
+			Count:           snapshot.Count,
+			Generation:      snapshot.Generation,
+			IsNotCumulative: snapshot.IsNotCumulative,
+			Ranges:          asRanges(snapshot.Breakdown)}
 	default:
 		panic(panicIncompatibleTypes)
 	}

--- a/go/tricorder/metric_test.go
+++ b/go/tricorder/metric_test.go
@@ -253,7 +253,7 @@ func TestAPI(t *testing.T) {
 	var speedInBytesPerSecond uint32
 
 	rpcBucketer := NewExponentialBucketer(6, 10, 2.5)
-	rpcDistribution := rpcBucketer.NewDistribution()
+	rpcDistribution := rpcBucketer.NewCumulativeDistribution()
 
 	if err := RegisterMetric(
 		"/bytes/bytes",
@@ -844,12 +844,13 @@ func TestAPI(t *testing.T) {
 	expected := &messages.Metric{
 		Kind: types.Dist,
 		Value: &messages.Distribution{
-			Min:     0.0,
-			Max:     499.0,
-			Average: 249.5,
-			Sum:     124750.0,
-			Median:  actual.Value.(*messages.Distribution).Median,
-			Count:   500,
+			Min:        0.0,
+			Max:        499.0,
+			Average:    249.5,
+			Sum:        124750.0,
+			Median:     actual.Value.(*messages.Distribution).Median,
+			Count:      500,
+			Generation: 500,
 			Ranges: []*messages.RangeWithCount{
 				{
 					Upper: 10.0,
@@ -894,12 +895,13 @@ func TestAPI(t *testing.T) {
 	expectedRpc := &messages.Metric{
 		Kind: types.Dist,
 		Value: &messages.Distribution{
-			Min:     0.0,
-			Max:     499.0,
-			Average: 249.5,
-			Sum:     124750.0,
-			Median:  actualRpc.Value.(*messages.Distribution).Median,
-			Count:   500,
+			Min:        0.0,
+			Max:        499.0,
+			Average:    249.5,
+			Sum:        124750.0,
+			Median:     actualRpc.Value.(*messages.Distribution).Median,
+			Count:      500,
+			Generation: 500,
 			Ranges: []*messages.RangeWithCount{
 				{
 					Upper: 10.0,
@@ -1004,9 +1006,10 @@ func TestArbitraryDistribution(t *testing.T) {
 		Max:     100.0,
 		Average: 50.5,
 		// Let exact matching pass
-		Median: actual.Median,
-		Sum:    5050.0,
-		Count:  100,
+		Median:     actual.Median,
+		Sum:        5050.0,
+		Count:      100,
+		Generation: 100,
 		Breakdown: breakdown{
 			{
 				bucketPiece: &bucketPiece{

--- a/go/tricorderdemo/tricorderdemo.go
+++ b/go/tricorderdemo/tricorderdemo.go
@@ -13,7 +13,7 @@ func registerMetrics() {
 	var temperature float64
 	var someBool bool
 
-	rpcDistribution := tricorder.PowersOfTen.NewDistribution()
+	rpcDistribution := tricorder.PowersOfTen.NewCumulativeDistribution()
 
 	if err := tricorder.RegisterMetric(
 		"/proc/rpc-latency",


### PR DESCRIPTION
This change also includes:
1. Introduce GenerationCount in JSON and GoRPC
2. Introduce IsNotCumulative in JSON and GoRPC
