### PR TITLE
Introduce NonCumulativeDistribution.Remove()

### DIFF
--- a/go/tricorder/api.go
+++ b/go/tricorder/api.go
@@ -182,6 +182,21 @@ func (d *NonCumulativeDistribution) Update(oldValue, newValue interface{}) {
 func (d *NonCumulativeDistribution) UpdateMinMax() {
 }
 
+// Remove removes a value from this NonCumulativeDistribution instance.
+// valueToBeRemoved can be a float32, float64, or a time.Duration.
+// If a time.Duration, Remove converts it to the same unit of time
+// specified in the RegisterMetric call made to register this instance.
+// The reliability of Remove() depends on the caller providing a value
+// already in the distribution. Failure to do this results in
+// undefined behavior.
+// Remove updates all distribution statistics in the expected way; however,
+// it leaves min and max unchanged.
+// To have min and max reflect the current min and max
+// instead of the all-time min and max, see UpdateMinMax().
+func (d *NonCumulativeDistribution) Remove(valueToBeRemoved interface{}) {
+	(*distribution)(d).Remove(valueToBeRemoved)
+}
+
 // Sum returns the sum of the values in this distribution.
 func (d *NonCumulativeDistribution) Sum() float64 {
 	return (*distribution)(d).Sum()

--- a/go/tricorder/metric.go
+++ b/go/tricorder/metric.go
@@ -285,6 +285,10 @@ func (d *distribution) Update(oldValue, newValue interface{}) {
 	d.update(d.valueToFloat(oldValue), d.valueToFloat(newValue))
 }
 
+func (d *distribution) Remove(valueToBeRemoved interface{}) {
+	d.remove(d.valueToFloat(valueToBeRemoved))
+}
+
 func (d *distribution) add(value float64) {
 	idx := findDistributionIndex(d.pieces, value)
 	d.lock.Lock()
@@ -322,6 +326,22 @@ func (d *distribution) update(oldValue, newValue float64) {
 	} else if newValue > d.max {
 		d.max = newValue
 	}
+	d.generation++
+}
+
+func (d *distribution) remove(valueToBeRemoved float64) {
+	if d.count == 0 {
+		panic("Can't call remove on an empty distribution.")
+	}
+	if !d.isNotCumulative {
+		panic("Cannot call remove on a cumulative distribution.")
+	}
+	idx := findDistributionIndex(d.pieces, valueToBeRemoved)
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	d.counts[idx]--
+	d.total -= valueToBeRemoved
+	d.count--
 	d.generation++
 }
 

--- a/go/tricorder/metric_test.go
+++ b/go/tricorder/metric_test.go
@@ -1013,6 +1013,10 @@ func TestArbitraryDistribution(t *testing.T) {
 	for i := 100; i >= 1; i-- {
 		dist.Update(100.0, float64(i))
 	}
+	for i := 0; i < 100; i++ {
+		dist.Add(100.0)
+		dist.Remove(100.0)
+	}
 	actual = dist.Snapshot()
 	if actual.Median < 49.5 || actual.Median >= 51.5 {
 		t.Errorf("Median out of range: %f", actual.Median)
@@ -1025,7 +1029,7 @@ func TestArbitraryDistribution(t *testing.T) {
 		Median:          actual.Median,
 		Sum:             5050.0,
 		Count:           100,
-		Generation:      200,
+		Generation:      400,
 		IsNotCumulative: true,
 		Breakdown: breakdown{
 			{


### PR DESCRIPTION
Richard, as I began work on reclaiming pages from metric values on no longer used machines, I discovered that I need a NonCumulativeDistribution.Remove() method. When a machine goes away, its metrics should no longer be counted in the pages per metric distribution.
