### PR TITLE
tricorder changes for scotty

### DIFF
--- a/go/tricorder/api.go
+++ b/go/tricorder/api.go
@@ -208,6 +208,11 @@ func (d *NonCumulativeDistribution) Sum() float64 {
 	return (*distribution)(d).Sum()
 }
 
+// Count returns the number of values in this distribution
+func (d *NonCumulativeDistribution) Count() uint64 {
+	return (*distribution)(d).Count()
+}
+
 // DirectorySpec represents a specific directory in the heirarchy of
 // metrics.
 type DirectorySpec directory

--- a/go/tricorder/metric.go
+++ b/go/tricorder/metric.go
@@ -278,6 +278,12 @@ func (d *distribution) Sum() float64 {
 	return d.total
 }
 
+func (d *distribution) Count() uint64 {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	return d.count
+}
+
 func (d *distribution) Add(value interface{}) {
 	d.add(d.valueToFloat(value))
 }

--- a/go/tricorder/types/api.go
+++ b/go/tricorder/types/api.go
@@ -1,6 +1,10 @@
 // Package types contains the various types for metric values.
 package types
 
+import (
+	"time"
+)
+
 // Type represents the type of a metric value
 type Type string
 
@@ -28,6 +32,47 @@ const (
 	// for GoRPC
 	GoDuration Type = "goDuration"
 )
+
+// ZeroValue returns the zero value for this type.
+// ZeroValue panics if this type is Dist.
+func (t Type) ZeroValue() interface{} {
+	switch t {
+	case Bool:
+		return false
+	case Int8:
+		return int8(0)
+	case Int16:
+		return int16(0)
+	case Int32:
+		return int32(0)
+	case Int64:
+		return int64(0)
+	case Uint8:
+		return uint8(0)
+	case Uint16:
+		return uint16(0)
+	case Uint32:
+		return uint32(0)
+	case Uint64:
+		return uint64(0)
+	case Float32:
+		return float32(0)
+	case Float64:
+		return float64(0)
+	case String:
+		return ""
+	case Dist:
+		panic("Dist type cannot create new value.")
+	case Time, Duration:
+		return "0.000000000"
+	case GoTime:
+		return time.Time{}
+	case GoDuration:
+		return time.Duration(0)
+	default:
+		panic("Unknown type")
+	}
+}
 
 func (t Type) IsInt() bool {
 	return t == Int8 || t == Int16 || t == Int32 || t == Int64


### PR DESCRIPTION
These are changes I made to tricorder for scotty:

The first change, adding a Count() method to non-cumulative distribution, is needed so that I can easily tell how many unique time series there are. With scotty 2.0, I need this to calculate page utilization since exactly one value, the latest value, per time series is not stored in a page.

The second change, adding the ZeroValue() method to the types instance. Is needed so that I can fill in a sensible 0 value for a missing metric.  With the scotty JSON, I plan to indicate a missing metric with a 0 value and an active flag set to false.
