### PR TITLE
Introduce Snapshot.

### DIFF
--- a/go/tricorder/api.go
+++ b/go/tricorder/api.go
@@ -143,6 +143,11 @@ func (c *CumulativeDistribution) Add(value interface{}) {
 	(*distribution)(c).Add(value)
 }
 
+// Snapshot fetches a snapshot of this instance
+func (c *CumulativeDistribution) Snapshot() *Snapshot {
+	return nil
+}
+
 // Unlike in CumulativeDistributions,values in NonCumulativeDistributions
 // can change shifting from bucket to bucket.
 type NonCumulativeDistribution distribution
@@ -211,6 +216,49 @@ func (d *NonCumulativeDistribution) Sum() float64 {
 // Count returns the number of values in this distribution
 func (d *NonCumulativeDistribution) Count() uint64 {
 	return (*distribution)(d).Count()
+}
+
+// Snapshot fetches a snapshot of this instance
+func (d *NonCumulativeDistribution) Snapshot() *Snapshot {
+	return nil
+}
+
+// Snapshot represents a snapshot of a cumulative or non-cumulative distribution
+// Snapshot instances are immutable.
+type Snapshot struct {
+	s snapshot
+}
+
+// Sum returns the sum of the values
+func (s *Snapshot) Sum() float64 {
+	return 0.0
+}
+
+// Count returns the number of values
+func (s *Snapshot) Count() uint64 {
+	return 0
+}
+
+// Median returns the estimated median of the values
+func (s *Snapshot) Median() float64 {
+	return 0.0
+}
+
+// Average returns the average of the values
+func (s *Snapshot) Average() float64 {
+	return 0.0
+}
+
+// Min returns the minimum value.
+// Min is accurate only if the distribution is cumulative.
+func (s *Snapshot) Min() float64 {
+	return 0.0
+}
+
+// Max returns the maximum value.
+// Man is accurate only if the distribution is cumulative.
+func (s *Snapshot) Max() float64 {
+	return 0.0
 }
 
 // DirectorySpec represents a specific directory in the heirarchy of

--- a/go/tricorder/doc.go
+++ b/go/tricorder/doc.go
@@ -171,6 +171,13 @@ Metric types:
 			&durationValue,
 			tricorder.None,
 			"duration value description")
+	*tricorder.Snapshot (see below)
+		tricorder.RegisterMetric(
+			"a/path/to/distribution",
+			&snapshotPointer,
+			tricorder.None,
+			"Caller decides when it pulls the distribution's state")
+
 
 If code generates a metric's value, register the callback function like so
 
@@ -197,5 +204,17 @@ safe to use from multiple goroutines.
 		globalDist.Add(getSomeFloatValue())
 		globalDist.Add(getAnotherFloatValue())
 	}
+
+When the caller registers a distribution, tricorder always reports the most
+current state of the distribution. Sometimes the reported state of a
+distribution must stay in sync with other metrics or the caller may want to
+report the state of the distribution at a particular time. In this case,
+the caller can control when it queries the distribution for its state by
+registering a *tricorder.Snapshot instead.
+
+To register a *tricorder.Snapshot, the caller passes the address of it
+(a **tricorder.Snapshot) to RegisterMetric. Then the caller can store the
+latest snapshot of the distribution in the *tricorder.Snapshot whenever it
+chooses.
 */
 package tricorder


### PR DESCRIPTION
In scotty. I have situations where tricorder should keep the state of distributions in sync with other metrics. 

For example, in scotty I show many pages are used for values and and how many pages are used for
timestamps and the total number of used pages. However, I also show a distribution of pages used per metric. 

The Sum field in the pages used per metric should equal the how many pages are used metric, but since tricorder always pulls the latest snapshot of a distribution when it is time to report it, these values can be out of sync. I pull the snapshot once to compute the "page in use" total. Then tricorder pulls the same snapshot again to display the distribution and between those two pulls the distribution can change.

I need to control when tricorder pulls the snapshot of metrics. For the example above, I would put the distribution and all related metrics in the same group. In my group update function, I would pull the snapshot of the pages per metric distribution ensuring that I pull the snapshot only one time per metric request. That way when tricorder presents its metrics, the sum field in the distribution of pages used per metric will always match the number of pages used for values, and the total number of pages used will be correct.

Having this fine grain control over when the snapshots of distributions is pulled is especially important since we are giving the caller control over the timestamps they report with each metric.

Again, this is just a straw man, a proof of concept. Please don't pull this, but we can discuss it.
