### PR TITLE
Introduce RegisterMetricInGroup. Deprecate RegisterMetricInRegion.

### DIFF
--- a/go/tricorder/api.go
+++ b/go/tricorder/api.go
@@ -70,10 +70,19 @@ func RegisterMetric(
 		newPathSpec(path), metric, nil, unit, description)
 }
 
-// RegisterMetricWithRegion works just like RegisterMetrics but allows
-// the caller to specify the region to which the variable or callback function
-// being registered belongs. RegisterMetricWithRegion ignores the region
-// parameter when registering a distribution.
+// RegisterMetricInGroup works just like RegisterMetric but allows
+// the caller to specify the group to which the variable or callback function
+// being registered belongs.
+func RegisterMetricInGroup(
+	path string,
+	metric interface{},
+	g *Group,
+	unit units.Unit,
+	description string) error {
+	return root.registerMetric(newPathSpec(path), metric, (*region)(g), unit, description)
+}
+
+// RegisterMetricInRegion is deprecated: See RegisterMetricInGroup.
 func RegisterMetricInRegion(
 	path string,
 	metric interface{},
@@ -260,9 +269,19 @@ func (d *DirectorySpec) RegisterMetric(
 	return (*directory)(d).registerMetric(newPathSpec(path), metric, nil, unit, description)
 }
 
-// RegisterMetricWithRegion works just like the package level
-// RegisterMetricWithRegion except that path is relative to this
+// RegisterMetricInGroup works just like the package level
+// RegisterMetricWithGroup except that path is relative to this
 // DirectorySpec.
+func (d *DirectorySpec) RegisterMetricInGroup(
+	path string,
+	metric interface{},
+	g *Group,
+	unit units.Unit,
+	description string) error {
+	return (*directory)(d).registerMetric(newPathSpec(path), metric, (*region)(g), unit, description)
+}
+
+// RegisterMetricInRegion is deprecated: See RegisterMetricInGroup.
 func (d *DirectorySpec) RegisterMetricInRegion(
 	path string,
 	metric interface{},

--- a/go/tricorder/metric_test.go
+++ b/go/tricorder/metric_test.go
@@ -29,38 +29,54 @@ var (
 )
 
 var (
+	kFirstAndSecondTime   = time.Date(2016, 4, 20, 11, 0, 0, 0, time.Local)
+	kThirdToSixthTime     = time.Date(2016, 4, 20, 12, 0, 0, 0, time.Local)
+	kSeventhAndEighthTime = time.Date(2016, 4, 20, 13, 0, 0, 0, time.Local)
+)
+
+var (
 	anIntFlag     int64
 	aDurationFlag time.Duration
 	aSliceFlag    flagValue
 	aUnitFlag     float64
 )
 
-func incrementFirstAndSecondGlobal() {
+func incrementFirstAndSecondGlobal() time.Time {
 	firstGlobal++
 	secondGlobal++
+	return kFirstAndSecondTime
+
 }
 
-func incrementThirdToSixthGlobal() {
+func incrementThirdToSixthGlobal() time.Time {
 	thirdGlobal++
 	fourthGlobal++
 	fifthGlobal++
 	sixthGlobal++
+	return kThirdToSixthTime
 }
 
-func incrementSeventhAndEighthGlobal() {
+func incrementSeventhAndEighthGlobal() time.Time {
 	seventhGlobal++
 	eighthGlobal++
+	return kSeventhAndEighthTime
+}
+
+func registerGroup(f func() time.Time) *Group {
+	result := NewGroup()
+	result.RegisterUpdateFunc(f)
+	return result
 }
 
 func registerMetricsForGlobalsTest() {
-	r1and2 := RegisterRegion(incrementFirstAndSecondGlobal)
-	r3to6 := RegisterRegion(incrementThirdToSixthGlobal)
-	r7and8 := RegisterRegion(incrementSeventhAndEighthGlobal)
-	RegisterMetricInRegion(
+	r1and2 := registerGroup(incrementFirstAndSecondGlobal)
+	r3to6 := registerGroup(incrementThirdToSixthGlobal)
+	r7and8 := registerGroup(incrementSeventhAndEighthGlobal)
+	RegisterMetricInGroup(
 		"/firstGroup/first", &firstGlobal, r1and2, units.None, "")
-	RegisterMetricInRegion(
+	RegisterMetricInGroup(
 		"/firstGroup/second", &secondGlobal, r1and2, units.None, "")
-	RegisterMetricInRegion(
+	RegisterMetricInGroup(
 		"/firstGroup/firstTimesSecond",
 		func() int {
 			return firstGlobal * secondGlobal
@@ -68,17 +84,17 @@ func registerMetricsForGlobalsTest() {
 		r1and2,
 		units.None,
 		"")
-	RegisterMetricInRegion(
+	RegisterMetricInGroup(
 		"/firstGroup/third", &thirdGlobal, r3to6, units.None, "")
-	RegisterMetricInRegion(
+	RegisterMetricInGroup(
 		"/firstGroup/fourth", &fourthGlobal, r3to6, units.None, "")
-	RegisterMetricInRegion(
+	RegisterMetricInGroup(
 		"/secondGroup/fifth", &fifthGlobal, r3to6, units.None, "")
-	RegisterMetricInRegion(
+	RegisterMetricInGroup(
 		"/secondGroup/sixth", &sixthGlobal, r3to6, units.None, "")
-	RegisterMetricInRegion(
+	RegisterMetricInGroup(
 		"/secondGroup/seventh", &seventhGlobal, r7and8, units.None, "")
-	RegisterMetricInRegion(
+	RegisterMetricInGroup(
 		"/secondGroup/eighth", &eighthGlobal, r7and8, units.None, "")
 }
 

--- a/go/tricorder/setup.go
+++ b/go/tricorder/setup.go
@@ -21,119 +21,123 @@ func timeValToDuration(val *wrapper.Timeval) time.Duration {
 func initDefaultMetrics() {
 	programArgs := getProgramArgs()
 	var memStats runtime.MemStats
-	memStatsRegion := RegisterRegion(func() {
+	memStatsGroup := NewGroup()
+	memStatsGroup.RegisterUpdateFunc(func() time.Time {
 		runtime.ReadMemStats(&memStats)
+		return time.Now()
 	})
-	RegisterMetricInRegion(
+	RegisterMetricInGroup(
 		"/proc/memory/total",
 		&memStats.Sys,
-		memStatsRegion,
+		memStatsGroup,
 		units.Byte,
 		"Memory system has allocated to process")
 	var resourceUsage wrapper.Rusage
 	var userTime time.Duration
 	var sysTime time.Duration
 	var maxResidentSetSize int64
-	resourceUsageRegion := RegisterRegion(func() {
+	resourceUsageGroup := NewGroup()
+	resourceUsageGroup.RegisterUpdateFunc(func() time.Time {
 		wrapper.Getrusage(syscall.RUSAGE_SELF, &resourceUsage)
 		userTime = timeValToDuration(&resourceUsage.Utime)
 		sysTime = timeValToDuration(&resourceUsage.Stime)
 		maxResidentSetSize = resourceUsage.Maxrss
+		return time.Now()
 	})
-	RegisterMetricInRegion(
+	RegisterMetricInGroup(
 		"/proc/cpu/user",
 		&userTime,
-		resourceUsageRegion,
+		resourceUsageGroup,
 		units.Second,
 		"User CPU time used")
-	RegisterMetricInRegion(
+	RegisterMetricInGroup(
 		"/proc/cpu/sys",
 		&sysTime,
-		resourceUsageRegion,
+		resourceUsageGroup,
 		units.Second,
 		"User CPU time used")
-	RegisterMetricInRegion(
+	RegisterMetricInGroup(
 		"/proc/memory/max-resident-set-size",
 		&maxResidentSetSize,
-		resourceUsageRegion,
+		resourceUsageGroup,
 		units.Byte,
 		"Maximum resident set size")
-	RegisterMetricInRegion(
+	RegisterMetricInGroup(
 		"/proc/memory/shared",
 		&resourceUsage.Ixrss,
-		resourceUsageRegion,
+		resourceUsageGroup,
 		units.Byte,
 		"Integral shared memory size")
-	RegisterMetricInRegion(
+	RegisterMetricInGroup(
 		"/proc/memory/unshared-data",
 		&resourceUsage.Idrss,
-		resourceUsageRegion,
+		resourceUsageGroup,
 		units.Byte,
 		"Integral unshared data size")
-	RegisterMetricInRegion(
+	RegisterMetricInGroup(
 		"/proc/memory/unshared-stack",
 		&resourceUsage.Isrss,
-		resourceUsageRegion,
+		resourceUsageGroup,
 		units.Byte,
 		"Integral unshared stack size")
-	RegisterMetricInRegion(
+	RegisterMetricInGroup(
 		"/proc/memory/soft-page-fault",
 		&resourceUsage.Minflt,
-		resourceUsageRegion,
+		resourceUsageGroup,
 		units.None,
 		"Soft page faults")
-	RegisterMetricInRegion(
+	RegisterMetricInGroup(
 		"/proc/memory/hard-page-fault",
 		&resourceUsage.Majflt,
-		resourceUsageRegion,
+		resourceUsageGroup,
 		units.None,
 		"Hard page faults")
-	RegisterMetricInRegion(
+	RegisterMetricInGroup(
 		"/proc/memory/swaps",
 		&resourceUsage.Nswap,
-		resourceUsageRegion,
+		resourceUsageGroup,
 		units.None,
 		"Swaps")
-	RegisterMetricInRegion(
+	RegisterMetricInGroup(
 		"/proc/io/input",
 		&resourceUsage.Inblock,
-		resourceUsageRegion,
+		resourceUsageGroup,
 		units.None,
 		"Block input operations")
-	RegisterMetricInRegion(
+	RegisterMetricInGroup(
 		"/proc/io/output",
 		&resourceUsage.Oublock,
-		resourceUsageRegion,
+		resourceUsageGroup,
 		units.None,
 		"Block output operations")
-	RegisterMetricInRegion(
+	RegisterMetricInGroup(
 		"/proc/ipc/sent",
 		&resourceUsage.Msgsnd,
-		resourceUsageRegion,
+		resourceUsageGroup,
 		units.None,
 		"IPC messages sent")
-	RegisterMetricInRegion(
+	RegisterMetricInGroup(
 		"/proc/ipc/received",
 		&resourceUsage.Msgrcv,
-		resourceUsageRegion,
+		resourceUsageGroup,
 		units.None,
 		"IPC messages received")
-	RegisterMetricInRegion(
+	RegisterMetricInGroup(
 		"/proc/signals/received",
 		&resourceUsage.Nsignals,
-		resourceUsageRegion,
+		resourceUsageGroup,
 		units.None,
 		"Signals received")
-	RegisterMetricInRegion(
+	RegisterMetricInGroup(
 		"/proc/scheduler/voluntary-switches",
 		&resourceUsage.Nvcsw,
-		resourceUsageRegion,
+		resourceUsageGroup,
 		units.None,
 		"Voluntary context switches")
-	RegisterMetricInRegion(
+	RegisterMetricInGroup(
 		"/proc/scheduler/involuntary-switches",
 		&resourceUsage.Nivcsw,
-		resourceUsageRegion,
+		resourceUsageGroup,
 		units.None,
 		"Involuntary context switches")
 	RegisterMetric("/proc/name", &os.Args[0], units.None, "Program name")


### PR DESCRIPTION
Fix deprecated calls to RegisterMetricInRegion in rest of tricorder.
