### PR TITLE
Introduce new duration package.

### DIFF
--- a/go/tricorder/duration/api.go
+++ b/go/tricorder/duration/api.go
@@ -1,0 +1,88 @@
+// Package duration provides utilities for dealing with times and durations.
+package duration
+
+import (
+	"github.com/Symantec/tricorder/go/tricorder/units"
+	"time"
+)
+
+// Duration represents a duration of time
+// For negative durations, both Seconds and Nanoseconds are negative.
+// Internal use only for now.
+type Duration struct {
+	Seconds     int64
+	Nanoseconds int32
+}
+
+func New(d time.Duration) Duration {
+	return newDuration(d)
+}
+
+// SinceEpoch returns the amount of time since unix epoch
+func SinceEpoch(now time.Time) Duration {
+	return sinceEpoch(now)
+}
+
+// SinceEpochFloat returns the amount of time since unix epoch
+func SinceEpochFloat(secondsSinceEpoch float64) Duration {
+	return sinceEpochFloat(secondsSinceEpoch)
+}
+
+// AsGoDuration converts this duration to a go duration
+func (d Duration) AsGoDuration() time.Duration {
+	return d.asGoDuration()
+}
+
+// AsGoTime Converts this duration to a go time in the
+// system's local time zone.
+func (d Duration) AsGoTime() time.Time {
+	return d.asGoTime()
+}
+
+// AsFloat returns this duration in seconds.
+func (d Duration) AsFloat() float64 {
+	return d.asFloat()
+}
+
+// String shows in seconds
+func (d Duration) String() string {
+	return d.stringUsingUnits(units.Second)
+}
+
+// StringUsingUnits shows in specified time unit.
+// If unit not a time, shows in seconds.
+func (d Duration) StringUsingUnits(unit units.Unit) string {
+	return d.stringUsingUnits(unit)
+}
+
+// IsNegative returns true if this duration is negative.
+func (d Duration) IsNegative() bool {
+	return d.isNegative()
+}
+
+// PrettyFormat pretty formats this duration.
+// PrettyFormat panics if this duration is negative.
+func (d Duration) PrettyFormat() string {
+	return d.prettyFormat()
+}
+
+// FloatToTime converts seconds after Jan 1, 1970 GMT to a time in the
+// system's local time zone.
+func FloatToTime(secondsSinceEpoch float64) time.Time {
+	return SinceEpochFloat(secondsSinceEpoch).AsGoTime()
+}
+
+// TimeToFloat returns t as seconds after Jan 1, 1970 GMT
+func TimeToFloat(t time.Time) (secondsSinceEpoch float64) {
+	return SinceEpoch(t).AsFloat()
+}
+
+// ToFloat returns d as seconds
+func ToFloat(d time.Duration) (seconds float64) {
+	return float64(d) / float64(time.Second)
+}
+
+// FromFloat converts a value in seconds to a duration
+func FromFloat(seconds float64) time.Duration {
+	return time.Duration(seconds*float64(time.Second) + 0.5)
+}

--- a/go/tricorder/duration/duration.go
+++ b/go/tricorder/duration/duration.go
@@ -1,4 +1,4 @@
-package messages
+package duration
 
 import (
 	"fmt"

--- a/go/tricorder/duration/duration_test.go
+++ b/go/tricorder/duration/duration_test.go
@@ -1,4 +1,4 @@
-package messages
+package duration
 
 import (
 	"github.com/Symantec/tricorder/go/tricorder/units"
@@ -6,13 +6,23 @@ import (
 	"time"
 )
 
+func TestConversions(t *testing.T) {
+	atime := time.Date(2016, 5, 25, 16, 9, 59, 0, time.Local)
+	assertValueEquals(t, 1464217799.0, TimeToFloat(atime))
+	assertValueEquals(t, atime, FloatToTime(1464217799.0))
+	assertValueEquals(
+		t, 3.625, ToFloat(3*time.Second+625*time.Millisecond))
+	assertValueEquals(
+		t, 3*time.Second+625*time.Millisecond, FromFloat(3.625))
+}
+
 func TestDuration(t *testing.T) {
 	var expected Duration
 	if expected.IsNegative() {
 		t.Error("Expected duration to be positive.")
 	}
 	var duration time.Duration
-	actual := NewDuration(duration)
+	actual := New(duration)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
@@ -21,7 +31,7 @@ func TestDuration(t *testing.T) {
 	}
 	expected = Duration{Seconds: 0, Nanoseconds: 1}
 	duration = time.Nanosecond
-	actual = NewDuration(duration)
+	actual = New(duration)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
@@ -33,7 +43,7 @@ func TestDuration(t *testing.T) {
 		t.Error("Expected duration to be positive.")
 	}
 	duration = time.Second
-	actual = NewDuration(duration)
+	actual = New(duration)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
@@ -42,7 +52,7 @@ func TestDuration(t *testing.T) {
 	}
 	expected = Duration{Seconds: 1, Nanoseconds: 999999999}
 	duration = 2*time.Second - time.Nanosecond
-	actual = NewDuration(duration)
+	actual = New(duration)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
@@ -54,7 +64,7 @@ func TestDuration(t *testing.T) {
 		t.Error("Expected duration to be negative.")
 	}
 	duration = -time.Nanosecond
-	actual = NewDuration(duration)
+	actual = New(duration)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
@@ -66,7 +76,7 @@ func TestDuration(t *testing.T) {
 		t.Error("Expected duration to be negative.")
 	}
 	duration = -time.Second
-	actual = NewDuration(duration)
+	actual = New(duration)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
@@ -75,7 +85,7 @@ func TestDuration(t *testing.T) {
 	}
 	expected = Duration{Seconds: -1, Nanoseconds: -999999999}
 	duration = -2*time.Second + time.Nanosecond
-	actual = NewDuration(duration)
+	actual = New(duration)
 	if expected != actual {
 		t.Errorf("Expected %v, got %v", expected, actual)
 	}
@@ -211,5 +221,11 @@ func TestPrettyFormat(t *testing.T) {
 func assertStringEquals(t *testing.T, expected, actual string) {
 	if expected != actual {
 		t.Errorf("Expected %s, got %s", expected, actual)
+	}
+}
+
+func assertValueEquals(t *testing.T, expected, actual interface{}) {
+	if expected != actual {
+		t.Errorf("Expected %v, got %v", expected, actual)
 	}
 }

--- a/go/tricorder/messages/api.go
+++ b/go/tricorder/messages/api.go
@@ -5,6 +5,7 @@ package messages
 import (
 	"encoding/gob"
 	"errors"
+	"github.com/Symantec/tricorder/go/tricorder/duration"
 	"github.com/Symantec/tricorder/go/tricorder/types"
 	"github.com/Symantec/tricorder/go/tricorder/units"
 	"time"
@@ -51,64 +52,24 @@ type Distribution struct {
 	Ranges []*RangeWithCount `json:"ranges,omitempty"`
 }
 
-// Duration represents a duration of time
-// For negative durations, both Seconds and Nanoseconds are negative.
-// Internal use only for now.
+// Deprecated: See tricorder/duration.Duration
 type Duration struct {
-	Seconds     int64
-	Nanoseconds int32
+	duration.Duration
 }
 
+// Deprecated: See tricorder/duration.New
 func NewDuration(d time.Duration) Duration {
-	return newDuration(d)
+	return Duration{duration.New(d)}
 }
 
-// SinceEpoch returns the amount of time since unix epoch
+// Deprecated: See tricorder/duration.SinceEpoch
 func SinceEpoch(t time.Time) Duration {
-	return sinceEpoch(t)
+	return Duration{duration.SinceEpoch(t)}
 }
 
-// SinceEpochFloat returns the amount of time since unix epoch
+// Deprecated: See tricorder/duration.SinceEpochFloat
 func SinceEpochFloat(f float64) Duration {
-	return sinceEpochFloat(f)
-}
-
-// AsGoDuration converts this duration to a go duration
-func (d Duration) AsGoDuration() time.Duration {
-	return d.asGoDuration()
-}
-
-// AsGoTime Converts this duration to a go time in the
-// system's local time zone.
-func (d Duration) AsGoTime() time.Time {
-	return d.asGoTime()
-}
-
-// AsFloat returns this duration in seconds.
-func (d Duration) AsFloat() float64 {
-	return d.asFloat()
-}
-
-// String shows in seconds
-func (d Duration) String() string {
-	return d.stringUsingUnits(units.Second)
-}
-
-// StringUsingUnits shows in specified time unit.
-// If unit not a time, shows in seconds.
-func (d Duration) StringUsingUnits(unit units.Unit) string {
-	return d.stringUsingUnits(unit)
-}
-
-// IsNegative returns true if this duration is negative.
-func (d Duration) IsNegative() bool {
-	return d.isNegative()
-}
-
-// PrettyFormat pretty formats this duration.
-// PrettyFormat panics if this duration is negative.
-func (d Duration) PrettyFormat() string {
-	return d.prettyFormat()
+	return Duration{duration.SinceEpochFloat(f)}
 }
 
 // Metric represents a single metric
@@ -181,20 +142,19 @@ func (m MetricList) AsJson() MetricList {
 	return m.asJson()
 }
 
-// FloatToTime converts seconds after Jan 1, 1970 GMT to a time in the
-// system's local time zone.
+// Deprecated: See tricorder/duration.FloatToTime
 func FloatToTime(secondsSinceEpoch float64) time.Time {
-	return SinceEpochFloat(secondsSinceEpoch).AsGoTime()
+	return duration.FloatToTime(secondsSinceEpoch)
 }
 
-// TimeToFloat returns t as seconds after Jan 1, 1970 GMT
-func TimeToFloat(t time.Time) float64 {
-	return SinceEpoch(t).AsFloat()
+// Deprecated: See tricorder/duration.TimeToFloat
+func TimeToFloat(t time.Time) (secondsSinceEpoch float64) {
+	return duration.TimeToFloat(t)
 }
 
-// DurationToFloat returns d as seconds
-func DurationToFloat(d time.Duration) float64 {
-	return NewDuration(d).AsFloat()
+// Deprecated: See tricorder/duration.DurationToFloat
+func DurationToFloat(d time.Duration) (seconds float64) {
+	return duration.ToFloat(d)
 }
 
 // IsJson returns true if kind is allowed in Json.

--- a/go/tricorder/messages/metric.go
+++ b/go/tricorder/messages/metric.go
@@ -1,6 +1,7 @@
 package messages
 
 import (
+	"github.com/Symantec/tricorder/go/tricorder/duration"
 	"github.com/Symantec/tricorder/go/tricorder/types"
 	"github.com/Symantec/tricorder/go/tricorder/units"
 	"time"
@@ -40,7 +41,7 @@ func (m *Metric) convertToJson() {
 	if m.TimeStamp == nil {
 		m.TimeStamp = ""
 	} else {
-		m.TimeStamp = SinceEpoch(m.TimeStamp.(time.Time)).String()
+		m.TimeStamp = duration.SinceEpoch(m.TimeStamp.(time.Time)).String()
 	}
 }
 
@@ -63,13 +64,13 @@ func (m MetricList) asJson() (result MetricList) {
 }
 
 func timeAsString(gotime time.Time, unit units.Unit) string {
-	var dur Duration
+	var dur duration.Duration
 	if !gotime.IsZero() {
-		dur = SinceEpoch(gotime)
+		dur = duration.SinceEpoch(gotime)
 	}
 	return dur.StringUsingUnits(unit)
 }
 
 func durationAsString(godur time.Duration, unit units.Unit) string {
-	return NewDuration(godur).StringUsingUnits(unit)
+	return duration.New(godur).StringUsingUnits(unit)
 }

--- a/go/tricorder/metric.go
+++ b/go/tricorder/metric.go
@@ -3,6 +3,7 @@ package tricorder
 import (
 	"flag"
 	"fmt"
+	"github.com/Symantec/tricorder/go/tricorder/duration"
 	"github.com/Symantec/tricorder/go/tricorder/messages"
 	"github.com/Symantec/tricorder/go/tricorder/types"
 	"github.com/Symantec/tricorder/go/tricorder/units"
@@ -767,16 +768,16 @@ func (v *value) AsGoDuration(s *session) time.Duration {
 	return time.Duration(v.evaluate(s).Int())
 }
 
-func (v *value) AsDuration(s *session) (result messages.Duration) {
+func (v *value) AsDuration(s *session) (result duration.Duration) {
 	if v.valType == types.GoTime {
 		t := v.AsTime(s)
 		if t.IsZero() {
 			return
 		}
-		return messages.SinceEpoch(t)
+		return duration.SinceEpoch(t)
 	}
 	if v.valType == types.GoDuration {
-		return messages.NewDuration(v.AsGoDuration(s))
+		return duration.New(v.AsGoDuration(s))
 	}
 	panic(panicIncompatibleTypes)
 }


### PR DESCRIPTION
Putting the Duration type and misc time conversion functions directly in the tricorder/messages packages finally bit me. The types packages will need access to these, but the messages package already depends on types.

So I decided to create a new package tricorder/duration to house the Duration type and misc time conversion functions.

This PR creates this new package and deprecates the corresponding artifacts in the messages package.
