### PR TITLE
Add CanToFromFloat, FromFloat, ToFloat to types.Type.

### DIFF
--- a/go/tricorder/metric.go
+++ b/go/tricorder/metric.go
@@ -783,6 +783,12 @@ func (v *value) AsDuration(s *session) (result duration.Duration) {
 }
 
 func (v *value) AsInterface(s *session) (result interface{}) {
+	// Int32, Int64, Uint32, and Uint64 cases are necessary in case
+	// client passed an int or uint pointer to RegisterMetric.
+	// If we were to just call v.evaluate(s).Interface() we would return
+	// that plain int or uint instead of a sized int or uint and violate
+	// the contract of the API which specifies that the value is always
+	// a sized int or uint.
 	switch v.valType {
 	case types.Int32:
 		return int32(v.AsInt(s))

--- a/go/tricorder/types/api.go
+++ b/go/tricorder/types/api.go
@@ -2,6 +2,7 @@
 package types
 
 import (
+	"github.com/Symantec/tricorder/go/tricorder/duration"
 	"time"
 )
 
@@ -71,6 +72,84 @@ func (t Type) ZeroValue() interface{} {
 		return time.Duration(0)
 	default:
 		panic("Unknown type")
+	}
+}
+
+// CanToFromFloat returns true if this type supports conversion to/from float64
+func (t Type) CanToFromFloat() bool {
+	switch t {
+	case Bool, String, Dist, Time, Duration:
+		return false
+	case Int8, Int16, Int32, Int64, Uint8, Uint16, Uint32, Uint64, Float32, Float64, GoTime, GoDuration:
+		return true
+	default:
+		panic("Unknown type")
+	}
+}
+
+// FromFloat converts a float64 to a value according to this type
+// FromFloat panics if this type doesn't support conversion from float64
+func (t Type) FromFloat(value float64) interface{} {
+	switch t {
+	case Int8:
+		return int8(round(value))
+	case Int16:
+		return int16(round(value))
+	case Int32:
+		return int32(round(value))
+	case Int64:
+		return int64(round(value))
+	case Uint8:
+		return uint8(round(value))
+	case Uint16:
+		return uint16(round(value))
+	case Uint32:
+		return uint32(round(value))
+	case Uint64:
+		return uint64(round(value))
+	case Float32:
+		return float32(value)
+	case Float64:
+		return value
+	case GoTime:
+		return duration.FloatToTime(value)
+	case GoDuration:
+		return duration.FromFloat(value)
+	default:
+		panic("Type doesn't support converstion from a float")
+	}
+}
+
+// ToFloat converts a value of this type to a float64
+// ToFloat panics if this type doesn't support conversion to float64
+func (t Type) ToFloat(x interface{}) float64 {
+	switch t {
+	case Int8:
+		return float64(x.(int8))
+	case Int16:
+		return float64(x.(int16))
+	case Int32:
+		return float64(x.(int32))
+	case Int64:
+		return float64(x.(int64))
+	case Uint8:
+		return float64(x.(uint8))
+	case Uint16:
+		return float64(x.(uint16))
+	case Uint32:
+		return float64(x.(uint32))
+	case Uint64:
+		return float64(x.(uint64))
+	case Float32:
+		return float64(x.(float32))
+	case Float64:
+		return x.(float64)
+	case GoTime:
+		return duration.TimeToFloat(x.(time.Time))
+	case GoDuration:
+		return duration.ToFloat(x.(time.Duration))
+	default:
+		panic("Type doesn't support conversion to float.")
 	}
 }
 

--- a/go/tricorder/types/types.go
+++ b/go/tricorder/types/types.go
@@ -1,0 +1,8 @@
+package types
+
+func round(f float64) float64 {
+	if f < 0 {
+		return f - 0.5
+	}
+	return f + 0.5
+}

--- a/go/tricorder/types/types_test.go
+++ b/go/tricorder/types/types_test.go
@@ -1,0 +1,136 @@
+package types_test
+
+import (
+	"github.com/Symantec/tricorder/go/tricorder/types"
+	"testing"
+)
+
+func TestZeroValue(t *testing.T) {
+	assertValueEquals(t, false, types.Bool.ZeroValue())
+	assertValueEquals(t, int8(0), types.Int8.ZeroValue())
+	assertValueEquals(t, int16(0), types.Int16.ZeroValue())
+	assertValueEquals(t, int32(0), types.Int32.ZeroValue())
+	assertValueEquals(t, int64(0), types.Int64.ZeroValue())
+	assertValueEquals(t, uint8(0), types.Uint8.ZeroValue())
+	assertValueEquals(t, uint16(0), types.Uint16.ZeroValue())
+	assertValueEquals(t, uint32(0), types.Uint32.ZeroValue())
+	assertValueEquals(t, uint64(0), types.Uint64.ZeroValue())
+	assertValueEquals(t, float32(0), types.Float32.ZeroValue())
+	assertValueEquals(t, 0.0, types.Float64.ZeroValue())
+	assertValueEquals(t, "", types.String.ZeroValue())
+}
+
+func TestCanToFromFloat(t *testing.T) {
+	assertValueEquals(t, false, types.Bool.CanToFromFloat())
+	assertValueEquals(t, true, types.Int8.CanToFromFloat())
+	assertValueEquals(t, true, types.Int16.CanToFromFloat())
+	assertValueEquals(t, true, types.Int32.CanToFromFloat())
+	assertValueEquals(t, true, types.Int64.CanToFromFloat())
+	assertValueEquals(t, true, types.Uint8.CanToFromFloat())
+	assertValueEquals(t, true, types.Uint16.CanToFromFloat())
+	assertValueEquals(t, true, types.Uint32.CanToFromFloat())
+	assertValueEquals(t, true, types.Uint64.CanToFromFloat())
+	assertValueEquals(t, true, types.Float32.CanToFromFloat())
+	assertValueEquals(t, true, types.Float64.CanToFromFloat())
+	assertValueEquals(t, false, types.String.CanToFromFloat())
+	assertValueEquals(t, false, types.Dist.CanToFromFloat())
+}
+
+func TestToFloat(t *testing.T) {
+	assertValueEquals(t, -128.0, types.Int8.ToFloat(int8(-128)))
+	assertValueEquals(t, 127.0, types.Int8.ToFloat(int8(127)))
+	assertValueEquals(t, 55.0, types.Int8.ToFloat(int8(55)))
+	assertValueEquals(t, -32768.0, types.Int16.ToFloat(int16(-32768)))
+	assertValueEquals(t, 32767.0, types.Int16.ToFloat(int16(32767)))
+	assertValueEquals(t, 55.0, types.Int16.ToFloat(int16(55)))
+	assertValueEquals(t, -2147483648.0, types.Int32.ToFloat(int32(-2147483648)))
+	assertValueEquals(t, 2147483647.0, types.Int32.ToFloat(int32(2147483647)))
+	assertValueEquals(t, 55.0, types.Int32.ToFloat(int32(55)))
+	assertValueEquals(t, 12345678901.0, types.Int64.ToFloat(int64(12345678901)))
+	assertValueEquals(t, -12345678901.0, types.Int64.ToFloat(int64(-12345678901)))
+	assertValueEquals(t, 0.0, types.Uint8.ToFloat(uint8(0)))
+	assertValueEquals(t, 255.0, types.Uint8.ToFloat(uint8(255)))
+	assertValueEquals(t, 55.0, types.Uint8.ToFloat(uint8(55)))
+	assertValueEquals(t, 0.0, types.Uint16.ToFloat(uint16(0)))
+	assertValueEquals(t, 65535.0, types.Uint16.ToFloat(uint16(65535)))
+	assertValueEquals(t, 55.0, types.Uint16.ToFloat(uint16(55)))
+	assertValueEquals(t, 0.0, types.Uint32.ToFloat(uint32(0)))
+	assertValueEquals(t, 4294967295.0, types.Uint32.ToFloat(uint32(4294967295)))
+	assertValueEquals(t, 55.0, types.Uint32.ToFloat(uint32(55)))
+	assertValueEquals(t, 12345678901.0, types.Uint64.ToFloat(uint64(12345678901)))
+	assertValueEquals(t, 0.0, types.Uint64.ToFloat(uint64(0)))
+
+	assertValueEquals(t, 69.25, types.Float32.ToFloat(float32(69.25)))
+	assertValueEquals(t, -38.375, types.Float32.ToFloat(float32(-38.375)))
+	assertValueEquals(t, 69.25, types.Float64.ToFloat(69.25))
+	assertValueEquals(t, -38.375, types.Float64.ToFloat(-38.375))
+}
+
+func TestFromFloat(t *testing.T) {
+	assertValueEquals(t, int8(-128), types.Int8.FromFloat(-128.0))
+	assertValueEquals(t, int8(-128), types.Int8.FromFloat(-128.49))
+	assertValueEquals(t, int8(-128), types.Int8.FromFloat(-127.5))
+	assertValueEquals(t, int8(-127), types.Int8.FromFloat(-127.49))
+	assertValueEquals(t, int8(0), types.Int8.FromFloat(0.0))
+	assertValueEquals(t, int8(1), types.Int8.FromFloat(0.5))
+	assertValueEquals(t, int8(0), types.Int8.FromFloat(0.49))
+	assertValueEquals(t, int8(127), types.Int8.FromFloat(127.49))
+
+	assertValueEquals(t, int16(-32768), types.Int16.FromFloat(-32768.0))
+	assertValueEquals(t, int16(-32768), types.Int16.FromFloat(-32768.49))
+	assertValueEquals(t, int16(-32768), types.Int16.FromFloat(-32767.5))
+	assertValueEquals(t, int16(-32767), types.Int16.FromFloat(-32767.49))
+	assertValueEquals(t, int16(0), types.Int16.FromFloat(0.0))
+	assertValueEquals(t, int16(1), types.Int16.FromFloat(0.5))
+	assertValueEquals(t, int16(0), types.Int16.FromFloat(0.49))
+	assertValueEquals(t, int16(32767), types.Int16.FromFloat(32767.49))
+
+	assertValueEquals(t, int32(-2147483648), types.Int32.FromFloat(-2147483648.0))
+	assertValueEquals(t, int32(-2147483648), types.Int32.FromFloat(-2147483648.49))
+	assertValueEquals(t, int32(-2147483648), types.Int32.FromFloat(-2147483647.5))
+	assertValueEquals(t, int32(-2147483647), types.Int32.FromFloat(-2147483647.49))
+	assertValueEquals(t, int32(0), types.Int32.FromFloat(0.0))
+	assertValueEquals(t, int32(1), types.Int32.FromFloat(0.5))
+	assertValueEquals(t, int32(0), types.Int32.FromFloat(0.49))
+	assertValueEquals(t, int32(2147483647), types.Int32.FromFloat(2147483647.49))
+
+	assertValueEquals(t, int64(-2147483648), types.Int64.FromFloat(-2147483648.0))
+	assertValueEquals(t, int64(-2147483648), types.Int64.FromFloat(-2147483648.49))
+	assertValueEquals(t, int64(-2147483648), types.Int64.FromFloat(-2147483647.5))
+	assertValueEquals(t, int64(-2147483647), types.Int64.FromFloat(-2147483647.49))
+	assertValueEquals(t, int64(0), types.Int64.FromFloat(0.0))
+	assertValueEquals(t, int64(1), types.Int64.FromFloat(0.5))
+	assertValueEquals(t, int64(0), types.Int64.FromFloat(0.49))
+	assertValueEquals(t, int64(2147483647), types.Int64.FromFloat(2147483647.49))
+
+	assertValueEquals(t, uint8(0), types.Uint8.FromFloat(0.0))
+	assertValueEquals(t, uint8(1), types.Uint8.FromFloat(0.5))
+	assertValueEquals(t, uint8(0), types.Uint8.FromFloat(0.49))
+	assertValueEquals(t, uint8(255), types.Uint8.FromFloat(255.49))
+
+	assertValueEquals(t, uint16(0), types.Uint16.FromFloat(0.0))
+	assertValueEquals(t, uint16(1), types.Uint16.FromFloat(0.5))
+	assertValueEquals(t, uint16(0), types.Uint16.FromFloat(0.49))
+	assertValueEquals(t, uint16(65535), types.Uint16.FromFloat(65535.49))
+
+	assertValueEquals(t, uint32(0), types.Uint32.FromFloat(0.0))
+	assertValueEquals(t, uint32(1), types.Uint32.FromFloat(0.5))
+	assertValueEquals(t, uint32(0), types.Uint32.FromFloat(0.49))
+	assertValueEquals(t, uint32(4294967295), types.Uint32.FromFloat(4294967295.49))
+
+	assertValueEquals(t, uint64(0), types.Uint64.FromFloat(0.0))
+	assertValueEquals(t, uint64(1), types.Uint64.FromFloat(0.5))
+	assertValueEquals(t, uint64(0), types.Uint64.FromFloat(0.49))
+	assertValueEquals(t, uint64(4294967295), types.Uint64.FromFloat(4294967295.49))
+
+	assertValueEquals(t, float32(69.25), types.Float32.FromFloat(69.25))
+	assertValueEquals(t, float32(-38.375), types.Float32.FromFloat(-38.375))
+	assertValueEquals(t, 69.25, types.Float64.FromFloat(69.25))
+	assertValueEquals(t, -38.375, types.Float64.FromFloat(-38.375))
+}
+
+func assertValueEquals(t *testing.T, expected, actual interface{}) {
+	if expected != actual {
+		t.Errorf("Expected %v, got %v", expected, actual)
+	}
+}


### PR DESCRIPTION
Same pull request as before but with the rounding bug fixed and additional tests.
