### PR TITLE
Support lists in tricorder

### DIFF
--- a/go/tricorder/api.go
+++ b/go/tricorder/api.go
@@ -261,46 +261,46 @@ const (
 // List instances are safe to use with multiple goroutines.
 type List listType
 
-// NewList returns a new list containing the values in aslice.
+// NewList returns a new list containing the values in aSlice.
 //
-// aslice must be a slice of any type that tricorder supports that
-// represents a single value. For example aslice can be an []int32,
+// aSlice must be a slice of any type that tricorder supports that
+// represents a single value. For example aSlice can be an []int32,
 // []int64, or []time.Time, but it cannot be a []*tricorder.List.
-// Moreover, aslice cannot be a slice of pointers such as []*int64.
-// NewList panics if aslice is not a slice or is a slice of an
+// Moreover, aSlice cannot be a slice of pointers such as []*int64.
+// NewList panics if aSlice is not a slice or is a slice of an
 // unsupported type.
 //
-// If caller passes an []int or []uint for aslice, NewList converts it
+// If caller passes an []int or []uint for aSlice, NewList converts it
 // internally to either an []int32, []int64, []uint32, []uint64 depending
 // on whether or not the architecture is 32 or 64 bit. This conversion happens
-// even if aSliceMutable is false and requires creating a copy of the slice.
-// Therefore, we recommend that for aslice caller always use
+// even if sliceIsMutable is false and requires creating a copy of the slice.
+// Therefore, we recommend that for aSlice caller always use
 // either []int32 or []int64 instead []int or either []uint32 or []uint64
 // instead of []uint.
 //
-// aSliceMutable lets tricorder know whether or not caller plans to
-// modify aslice in the future. If caller passes ImmutableSlice or
-// false for aSliceMutable and later modifies aslice, the results
+// sliceIsMutable lets tricorder know whether or not caller plans to
+// modify aSlice in the future. If caller passes ImmutableSlice or
+// false for sliceIsMutable and later modifies aSlice, the results
 // are undefined. If caller passes MutableSlice or true and later
-// modifies aslice, tricorder will continue to report the original
-// values in aslice.
+// modifies aSlice, tricorder will continue to report the original
+// values in aSlice.
 //
 // To change the values in a List, caller must use the Change method.
-func NewList(aslice interface{}, aSliceMutable bool) *List {
-	return (*List)(newListWithTimeStamp(aslice, aSliceMutable, time.Now()))
+func NewList(aSlice interface{}, sliceIsMutable bool) *List {
+	return (*List)(newListWithTimeStamp(aSlice, sliceIsMutable, time.Now()))
 }
 
 // Change updates this instance so that it contains only the values
-// found in aslice.
+// found in aSlice.
 //
 // Change panics if it would change the type of elements this instance
 // contains. For instance, creating a list with a []int64 and then calling
 // Change with a []string panics.
 //
-// The parameters aslice and aSliceMutable work the same way as in
+// The parameters aSlice and sliceIsMutable work the same way as in
 // NewList.
-func (l *List) Change(aslice interface{}, aSliceMutable bool) {
-	(*listType)(l).ChangeWithTimeStamp(aslice, aSliceMutable, time.Now())
+func (l *List) Change(aSlice interface{}, sliceIsMutable bool) {
+	(*listType)(l).ChangeWithTimeStamp(aSlice, sliceIsMutable, time.Now())
 }
 
 // DirectorySpec represents a specific directory in the heirarchy of

--- a/go/tricorder/api.go
+++ b/go/tricorder/api.go
@@ -250,6 +250,59 @@ func (d *NonCumulativeDistribution) Count() uint64 {
 	return (*distribution)(d).Count()
 }
 
+const (
+	// Indicates that passed slice may change.
+	MutableSlice = true
+	// Indicates that passed slice will never change.
+	ImmutableSlice = false
+)
+
+// List represents a metric that is a list of values of the same type.
+// List instances are safe to use with multiple goroutines.
+type List listType
+
+// NewList returns a new list containing the values in aslice.
+//
+// aslice must be a slice of any type that tricorder supports that
+// represents a single value. For example aslice can be an []int32,
+// []int64, or []time.Time, but it cannot be a []*tricorder.List.
+// Moreover, aslice cannot be a slice of pointers such as []*int64.
+// NewList panics if aslice is not a slice or is a slice of an
+// unsupported type.
+//
+// If caller passes an []int or []uint for aslice, NewList converts it
+// internally to either an []int32, []int64, []uint32, []uint64 depending
+// on whether or not the architecture is 32 or 64 bit. This conversion happens
+// even if aSliceMutable is false and requires creating a copy of the slice.
+// Therefore, we recommend that for aslice caller always use
+// either []int32 or []int64 instead []int or either []uint32 or []uint64
+// instead of []uint.
+//
+// aSliceMutable lets tricorder know whether or not caller plans to
+// modify aslice in the future. If caller passes ImmutableSlice or
+// false for aSliceMutable and later modifies aslice, the results
+// are undefined. If caller passes MutableSlice or true and later
+// modifies aslice, tricorder will continue to report the original
+// values in aslice.
+//
+// To change the values in a List, caller must use the Change method.
+func NewList(aslice interface{}, aSliceMutable bool) *List {
+	return (*List)(newListWithTimeStamp(aslice, aSliceMutable, time.Now()))
+}
+
+// Change updates this instance so that it contains only the values
+// found in aslice.
+//
+// Change panics if it would change the type of elements this instance
+// contains. For instance, creating a list with a []int64 and then calling
+// Change with a []string panics.
+//
+// The parameters aslice and aSliceMutable work the same way as in
+// NewList.
+func (l *List) Change(aslice interface{}, aSliceMutable bool) {
+	(*listType)(l).ChangeWithTimeStamp(aslice, aSliceMutable, time.Now())
+}
+
 // DirectorySpec represents a specific directory in the heirarchy of
 // metrics.
 type DirectorySpec directory

--- a/go/tricorder/doc.go
+++ b/go/tricorder/doc.go
@@ -199,5 +199,21 @@ add values. Distribution instances are safe to use from multiple goroutines.
 		globalDist.Add(getSomeFloatValue())
 		globalDist.Add(getAnotherFloatValue())
 	}
+
+Tricorder can store a list of values in a metric. In lists,
+values are always of the same type.
+List instances are safe to use from multiple goroutines.
+
+	globalList := tricorder.NewList(
+		[]int{2,3,5,7}, tricorder.ImmutableSlice)
+	tricorder.RegisterMetric(
+		"path/to/list",
+		globalList,
+		tricorder.None,
+		"A list description")
+
+	func doSomethingDuringProgram() {
+		globalList.Change([]int{1,4,9,16}, tricorder.ImmutableSlice)
+	}
 */
 package tricorder

--- a/go/tricorder/messages/api.go
+++ b/go/tricorder/messages/api.go
@@ -88,6 +88,8 @@ type Metric struct {
 	Unit units.Unit `json:"unit"`
 	// The metric's type
 	Kind types.Type `json:"kind"`
+	// The sub-type if type is an aggregate such as List.
+	SubType types.Type `json:"subType,omitempty"`
 	// The size in bits of metric's value if Kind is
 	// types.IntXX, types.UintXX, or types.FloatXX.
 	Bits int `json:"bits,omitempty"`
@@ -107,7 +109,7 @@ type Metric struct {
 
 // IsJson returns true if this metric is json compatible
 func (m *Metric) IsJson() bool {
-	return isJson(m.Kind)
+	return isJson(m.Kind, m.SubType)
 }
 
 // ConvertToJson changes this metric in place to be json compatible.
@@ -125,16 +127,39 @@ func (m MetricList) AsJson() MetricList {
 	return m.asJson()
 }
 
-// IsJson returns true if kind is allowed in Json.
+// Deprecated. See IsJsonWithSubType.
+// IsJson(kind) is equivalent to IsJsonWithSubType(kind, types.Unknown)
 func IsJson(kind types.Type) bool {
-	return isJson(kind)
+	return isJson(kind, types.Unknown)
 }
 
-// AsJson takes a metric value, kind, and unit and returns an acceptable
-// JSON value and kind for given unit.
+// IsJsonWithSubType returns true if given kind and subType are allowed in
+// JSON.
+// If kind is types.List subtype indicates the type of the elements in
+// the list. Otherwise, caller should pass types.Unknown for subType.
+func IsJsonWithSubType(kind, subType types.Type) bool {
+	return isJson(kind, subType)
+}
+
+// Deprecated. See AsJsonWithSubType.
+// Equivalent to IsJsonWithSubType(value, kind, types.Unknown, unit) except
+// does not return a sub type.
 func AsJson(value interface{}, kind types.Type, unit units.Unit) (
 	jsonValue interface{}, jsonKind types.Type) {
-	return asJson(value, kind, unit)
+	jsonValue, jsonKind, _ = asJson(value, kind, types.Unknown, unit)
+	return
+}
+
+// AsJsonWithSubType takes a metric value, kind, subtype, and unit and returns
+// an acceptable JSON value, kind, and subType for given unit.
+// If kind is types.List, subType indicates the type of elements in the list.
+// Otherwise, caller should pass types.Unknown for subType. Likewise, if
+// returned jsonKind is types.List, jsonSubType is the type of elements in
+// the list. Otherwise jsonSubType is types.Unknown.
+func AsJsonWithSubType(
+	value interface{}, kind, subType types.Type, unit units.Unit) (
+	jsonValue interface{}, jsonKind, jsonSubType types.Type) {
+	return asJson(value, kind, subType, unit)
 }
 
 func init() {

--- a/go/tricorder/metric.go
+++ b/go/tricorder/metric.go
@@ -23,6 +23,7 @@ const (
 	panicIncompatibleTypes      = "Wrong AsXXX function called on value."
 	panicTypeMismatch           = "Wrong type passed to method."
 	panicDirectoryUnregistered  = "Directory is unregistered."
+	panicSingleValueExpected    = "Trying to use an aggregate value in a single value context"
 )
 
 var (
@@ -520,11 +521,151 @@ func (d *distribution) Snapshot() *snapshot {
 
 }
 
+type listType struct {
+	groupId   int
+	subType   types.Type
+	lock      sync.RWMutex
+	aslice    reflect.Value
+	timeStamp time.Time
+}
+
+func copySlice(value reflect.Value) reflect.Value {
+	result := reflect.MakeSlice(value.Type(), value.Len(), value.Len())
+	reflect.Copy(result, value)
+	return result
+}
+
+// Converts []int or []uint slice to a slice having element type t.
+// If value is an []int, t has to be types.Int32 or types.Int64.
+// If value is an []uint, t has to be types.Uint32 or types.Uint64.
+func convertFromIntOrUintSlice(
+	value reflect.Value, t types.Type) reflect.Value {
+	var newType reflect.Type
+	switch t {
+	case types.Int32:
+		var unused []int32
+		newType = reflect.TypeOf(unused)
+	case types.Int64:
+		var unused []int64
+		newType = reflect.TypeOf(unused)
+	case types.Uint32:
+		var unused []uint32
+		newType = reflect.TypeOf(unused)
+	case types.Uint64:
+		var unused []uint64
+		newType = reflect.TypeOf(unused)
+	default:
+		panic("t is not compatible with int or uint")
+	}
+	length := value.Len()
+	defensiveCopy := reflect.MakeSlice(newType, length, length)
+	for i := 0; i < length; i++ {
+		defensiveCopy.Index(i).Set(
+			reflect.ValueOf(
+				valueToInterface(
+					value.Index(i),
+					t,
+					false)))
+	}
+	return defensiveCopy
+}
+
+// Returns aslice as a value and its type. If aSliceMutable is true,
+// always makes a defensive copy of aslice. If aSliceMutable is false,
+// may or may not make a defensive copy of aslice. If aslice is an []int
+// or []uint, returned value will be size specific, e.g []int64.
+func asSliceValue(aslice interface{}, aSliceMutable bool) (
+	value reflect.Value, t types.Type) {
+	value = reflect.ValueOf(aslice)
+	if value.Kind() != reflect.Slice {
+		panic("Slice expected")
+	}
+	elemType := value.Type().Elem()
+	t, isPtr := mustGetPrimitiveType(elemType)
+	if isPtr {
+		panic("Lists cannot contain slices of pointrs.")
+	}
+	elemKind := elemType.Kind()
+	if elemKind == reflect.Int || elemKind == reflect.Uint {
+		value = convertFromIntOrUintSlice(value, t)
+	} else if aSliceMutable {
+		value = copySlice(value)
+	}
+	return
+}
+
+func newListWithTimeStamp(
+	aslice interface{},
+	aSliceMutable bool,
+	ts time.Time) *listType {
+	value, subType := asSliceValue(aslice, aSliceMutable)
+	return &listType{
+		groupId:   <-idGenerator,
+		subType:   subType,
+		aslice:    value,
+		timeStamp: ts}
+}
+
+func (l *listType) ChangeWithTimeStamp(
+	aslice interface{},
+	aSliceMutable bool,
+	ts time.Time) {
+	value, subType := asSliceValue(aslice, aSliceMutable)
+	if subType != l.subType {
+		panic("Sub-type in list cannot change.")
+	}
+	l.lock.Lock()
+	defer l.lock.Unlock()
+	l.aslice = value
+	l.timeStamp = ts
+}
+
+func (l *listType) get() (value reflect.Value, ts time.Time) {
+	l.lock.RLock()
+	defer l.lock.RUnlock()
+	return l.aslice, l.timeStamp
+}
+
+func (l *listType) TextStrings(unit units.Unit) []string {
+	value, _ := l.get()
+	result := make([]string, value.Len())
+	for i := range result {
+		result[i] = valueToTextString(
+			value.Index(i), l.subType, unit, false)
+	}
+	return result
+}
+
+func (l *listType) HtmlStrings(unit units.Unit) []string {
+	value, _ := l.get()
+	result := make([]string, value.Len())
+	for i := range result {
+		result[i] = valueToHtmlString(
+			value.Index(i), l.subType, unit, false)
+	}
+	return result
+}
+
+// Callers must never modify returned slice in place.
+func (l *listType) AsSlice() (interface{}, time.Time) {
+	value, ts := l.get()
+	return value.Interface(), ts
+}
+
+func (l *listType) GroupId() int {
+	return l.groupId
+}
+
+func (l *listType) SubType() types.Type {
+	return l.subType
+}
+
 // value represents the value of a metric.
 type value struct {
 	val           reflect.Value
 	region        *region
 	dist          *distribution
+	alist         *listType
 	valType       types.Type
 	isValAPointer bool
 	isfunc        bool
@@ -627,6 +768,13 @@ func newValue(spec interface{}, region *region, unit units.Unit) *value {
 		dist.unit = unit
 		return &value{dist: dist, unit: unit, valType: types.Dist}
 	}
+	if someList, ok := spec.(*List); ok {
+		alist := (*listType)(someList)
+		return &value{alist: alist, unit: unit, valType: types.List}
+	}
+	if alist, ok := spec.(*listType); ok {
+		return &value{alist: alist, unit: unit, valType: types.List}
+	}
 	flagValue, ok := spec.(flag.Value)
 	if ok {
 		flagGetter := toFlagGetter(flagValue)
@@ -681,15 +829,32 @@ func (v *value) Type() types.Type {
 	return v.valType
 }
 
+// SubType returns the sub type of this value when this value is a
+// list or types.Unknown if this value is not a list.
+func (v *value) SubType() types.Type {
+	if v.valType == types.List {
+		return v.alist.SubType()
+	}
+	return types.Unknown
+}
+
 // Unit returns the unit of this value.
 func (v *value) Unit() units.Unit {
 	return v.unit
 }
 
 // Bits returns the size in bits if the type is an Int, Uint, or Float.
-// Otherwise Bits returns 0.
+// Otherwise Bits returns 0. If this value represents a list,
+// returns the size in bits of the sub type.
 func (v *value) Bits() int {
+	if v.valType == types.List {
+		return v.alist.SubType().Bits()
+	}
 	return v.valType.Bits()
+}
+
+func (v *value) canEvaluate() bool {
+	return v.val.IsValid()
 }
 
 func (v *value) evaluate(s *session) reflect.Value {
@@ -750,32 +915,46 @@ func (v *value) AsString(s *session) string {
 	return v.evaluate(s).String()
 }
 
-func (v *value) AsTime(s *session) (result time.Time) {
-	if v.valType != types.GoTime {
-		panic(panicIncompatibleTypes)
-	}
-	val := v.evaluate(s)
-	if v.isValAPointer {
-		p := val.Interface().(*time.Time)
+func valueToTime(
+	value reflect.Value, isValueAPointer bool) (result time.Time) {
+	if isValueAPointer {
+		p := value.Interface().(*time.Time)
 		if p == nil {
 			return
 		}
 		return *p
 	}
-	return val.Interface().(time.Time)
+	return value.Interface().(time.Time)
+}
+
+func valueToGoDuration(value reflect.Value) time.Duration {
+	return time.Duration(value.Int())
+}
+
+func timeToDuration(t time.Time) (result duration.Duration) {
+	if t.IsZero() {
+		return
+	}
+	return duration.SinceEpoch(t)
+}
+
+func (v *value) AsTime(s *session) (result time.Time) {
+	if v.valType != types.GoTime {
+		panic(panicIncompatibleTypes)
+	}
+	return valueToTime(v.evaluate(s), v.isValAPointer)
 }
 
 func (v *value) AsGoDuration(s *session) time.Duration {
-	return time.Duration(v.evaluate(s).Int())
+	if v.valType != types.GoDuration {
+		panic(panicIncompatibleTypes)
+	}
+	return valueToGoDuration(v.evaluate(s))
 }
 
-func (v *value) AsDuration(s *session) (result duration.Duration) {
+func (v *value) AsDuration(s *session) duration.Duration {
 	if v.valType == types.GoTime {
-		t := v.AsTime(s)
-		if t.IsZero() {
-			return
-		}
-		return duration.SinceEpoch(t)
+		return timeToDuration(v.AsTime(s))
 	}
 	if v.valType == types.GoDuration {
 		return duration.New(v.AsGoDuration(s))
@@ -783,34 +962,47 @@ func (v *value) AsDuration(s *session) (result duration.Duration) {
 	panic(panicIncompatibleTypes)
 }
 
-func (v *value) AsInterface(s *session) (result interface{}) {
+func valueToInterface(
+	value reflect.Value,
+	t types.Type,
+	isValueAPointer bool) interface{} {
 	// Int32, Int64, Uint32, and Uint64 cases are necessary in case
 	// client passed an int or uint pointer to RegisterMetric.
 	// If we were to just call v.evaluate(s).Interface() we would return
 	// that plain int or uint instead of a sized int or uint and violate
 	// the contract of the API which specifies that the value is always
 	// a sized int or uint.
-	switch v.valType {
-	case types.Int32:
-		return int32(v.AsInt(s))
-	case types.Int64:
-		return int64(v.AsInt(s))
-	case types.Uint32:
-		return uint32(v.AsUint(s))
-	case types.Uint64:
-		return uint64(v.AsUint(s))
-	case types.GoTime:
-		return v.AsTime(s)
-	case types.GoDuration:
-		return v.AsGoDuration(s)
+	switch {
+	case t == types.Int32 && !isValueAPointer:
+		return int32(value.Int())
+	case t == types.Int64 && !isValueAPointer:
+		return int64(value.Int())
+	case t == types.Uint32 && !isValueAPointer:
+		return uint32(value.Uint())
+	case t == types.Uint64 && !isValueAPointer:
+		return uint64(value.Uint())
+	case t == types.GoTime:
+		return valueToTime(value, isValueAPointer)
+	case t == types.GoDuration:
+		return valueToGoDuration(value)
+	case !isValueAPointer:
+		return value.Interface()
 	default:
-		return v.evaluate(s).Interface()
+		panic(panicIncompatibleTypes)
 	}
+
+}
+
+func (v *value) AsInterface(s *session) (result interface{}) {
+	if !v.canEvaluate() {
+		panic(panicSingleValueExpected)
+	}
+	return valueToInterface(v.evaluate(s), v.valType, v.isValAPointer)
 }
 
 // RegionId returns the region id for the timestamps of this value.
-// RegionId panics if called on a distribution value since distributions
-// are updated continually and have no timestamp.
+// RegionId panics if called on an aggregate value such as a distrubtion or
+// list since they are updated continually.
 func (v *value) RegionId() int {
 	if v.region == nil {
 		panic("Cannot all RegionId on a distribution value.")
@@ -822,11 +1014,11 @@ func (v *value) RegionId() int {
 // s must be non-nil and must be the same session passed to an AsXXX method
 // to fetch the value. The caller may call this method and the AsXXX method
 // in any order as long as it passes the same session to both.
-// TimeStamp panics if called on a distribution value since distributions
-// are updated continually and have no timestamp.
+// TimeStamp panics if called on an aggregat value such as a  distribution
+// or list since they are updated continually and have no timestamp.
 func (v *value) TimeStamp(s *session) time.Time {
 	if v.region == nil {
-		panic("Cannot call TimeStamp on a distribution value.")
+		panic("Cannot call TimeStamp on an aggregate value.")
 	}
 	return s.Visit(v.region)
 }
@@ -846,6 +1038,7 @@ func (v *value) updateJsonOrRpcMetric(
 	s *session, metric *messages.Metric, encoding rpcEncoding) {
 	t := v.Type()
 	metric.Kind = t
+	metric.SubType = v.SubType()
 	metric.Bits = v.Bits()
 	metric.Unit = v.Unit()
 	switch t {
@@ -861,6 +1054,10 @@ func (v *value) updateJsonOrRpcMetric(
 			Generation:      snapshot.Generation,
 			IsNotCumulative: snapshot.IsNotCumulative,
 			Ranges:          asRanges(snapshot.Breakdown)}
+	case types.List:
+		alist := v.AsList()
+		metric.Value, metric.TimeStamp = alist.AsSlice()
+		metric.GroupId = alist.GroupId()
 	default:
 		if s == nil {
 			s = newSession()
@@ -885,33 +1082,49 @@ func (v *value) UpdateRpcMetric(s *session, metric *messages.Metric) {
 	v.updateJsonOrRpcMetric(s, metric, goRpcEncoding)
 }
 
+func valueToTextString(
+	value reflect.Value,
+	t types.Type,
+	u units.Unit,
+	isValueAPointer bool) string {
+	switch {
+	case t == types.Bool:
+		if value.Bool() {
+			return "true"
+		}
+		return "false"
+	case t.IsInt() && !isValueAPointer:
+		return strconv.FormatInt(value.Int(), 10)
+	case t.IsUint() && !isValueAPointer:
+		return strconv.FormatUint(value.Uint(), 10)
+	case t == types.Float32 && !isValueAPointer:
+		return strconv.FormatFloat(value.Float(), 'f', -1, 32)
+	case t == types.Float64 && !isValueAPointer:
+		return strconv.FormatFloat(value.Float(), 'f', -1, 64)
+	case t == types.String && !isValueAPointer:
+		return "\"" + value.String() + "\""
+	case t == types.GoTime:
+		return timeToDuration(
+			valueToTime(
+				value, isValueAPointer)).StringUsingUnits(u)
+	case t == types.GoDuration && !isValueAPointer:
+		return duration.New(
+			valueToGoDuration(value)).StringUsingUnits(u)
+	default:
+		panic(panicIncompatibleTypes)
+	}
+}
+
 // AsTextString returns this value as a text friendly string.
 // AsTextString panics if this value does not represent a single value.
 // For example, AsTextString panics if this value represents a distribution.
 // If caller passes a nil session, AsTextString creates its own internally.
 func (v *value) AsTextString(s *session) string {
-	t := v.Type()
-	switch {
-	case t == types.Bool:
-		if v.AsBool(s) {
-			return "true"
-		}
-		return "false"
-	case t.IsInt():
-		return strconv.FormatInt(v.AsInt(s), 10)
-	case t.IsUint():
-		return strconv.FormatUint(v.AsUint(s), 10)
-	case t == types.Float32:
-		return strconv.FormatFloat(v.AsFloat(s), 'f', -1, 32)
-	case t == types.Float64:
-		return strconv.FormatFloat(v.AsFloat(s), 'f', -1, 64)
-	case t == types.String:
-		return "\"" + v.AsString(s) + "\""
-	case t == types.GoTime, t == types.GoDuration:
-		return v.AsDuration(s).StringUsingUnits(v.unit)
-	default:
-		panic(panicIncompatibleTypes)
+	if !v.canEvaluate() {
+		panic(panicSingleValueExpected)
 	}
+	return valueToTextString(
+		v.evaluate(s), v.Type(), v.unit, v.isValAPointer)
 }
 
 func iCompactForm(x int64, radix uint, suffixes []string) string {
@@ -956,49 +1169,61 @@ func uCompactForm(x uint64, radix uint, suffixes []string) string {
 	}
 }
 
+func valueToHtmlString(
+	value reflect.Value,
+	t types.Type,
+	u units.Unit,
+	isValueAPointer bool) string {
+	switch {
+	case t.IsInt() && !isValueAPointer:
+		switch u {
+		case units.Byte:
+			return iCompactForm(
+				value.Int(), 1024, byteSuffixes)
+		case units.BytePerSecond:
+			return iCompactForm(
+				value.Int(), 1024, bytePerSecondSuffixes)
+		default:
+			return iCompactForm(
+				value.Int(), 1000, suffixes)
+		}
+	case t.IsUint() && !isValueAPointer:
+		switch u {
+		case units.Byte:
+			return uCompactForm(
+				value.Uint(), 1024, byteSuffixes)
+		case units.BytePerSecond:
+			return uCompactForm(
+				value.Uint(), 1024, bytePerSecondSuffixes)
+		default:
+			return uCompactForm(
+				value.Uint(), 1000, suffixes)
+		}
+	case t == types.GoDuration && !isValueAPointer:
+		d := duration.New(valueToGoDuration(value))
+		if d.IsNegative() {
+			return valueToTextString(
+				value, t, u, isValueAPointer)
+		}
+		return d.PrettyFormat()
+	case t == types.GoTime:
+		t := valueToTime(value, isValueAPointer).UTC()
+		return t.Format("2006-01-02T15:04:05.999999999Z")
+	default:
+		return valueToTextString(value, t, u, isValueAPointer)
+	}
+}
+
 // AsHtmlString returns this value as an html friendly string.
 // AsHtmlString panics if this value does not represent a single value.
 // For example, AsHtmlString panics if this value represents a distribution.
 // If caller passes a nil session, AsHtmlString creates its own internally.
 func (v *value) AsHtmlString(s *session) string {
-	t := v.Type()
-	switch {
-	case t.IsInt():
-		switch v.unit {
-		case units.Byte:
-			return iCompactForm(v.AsInt(s), 1024, byteSuffixes)
-		case units.BytePerSecond:
-			return iCompactForm(
-				v.AsInt(s), 1024, bytePerSecondSuffixes)
-		default:
-			return iCompactForm(v.AsInt(s), 1000, suffixes)
-		}
-	case t.IsUint():
-		switch v.unit {
-		case units.Byte:
-			return uCompactForm(v.AsUint(s), 1024, byteSuffixes)
-		case units.BytePerSecond:
-			return uCompactForm(
-				v.AsUint(s), 1024, bytePerSecondSuffixes)
-		default:
-			return uCompactForm(v.AsUint(s), 1000, suffixes)
-		}
-	case t == types.GoDuration:
-		if s == nil {
-			s = newSession()
-			defer s.Close()
-		}
-		d := v.AsDuration(s)
-		if d.IsNegative() {
-			return v.AsTextString(s)
-		}
-		return d.PrettyFormat()
-	case t == types.GoTime:
-		t := v.AsTime(s).UTC()
-		return t.Format("2006-01-02T15:04:05.999999999Z")
-	default:
-		return v.AsTextString(s)
+	if !v.canEvaluate() {
+		panic(panicSingleValueExpected)
 	}
+	return valueToHtmlString(
+		v.evaluate(s), v.Type(), v.unit, v.isValAPointer)
 }
 
 // AsDistribution returns this value as a Distribution.
@@ -1008,6 +1233,13 @@ func (v *value) AsDistribution() *distribution {
 		panic(panicIncompatibleTypes)
 	}
 	return v.dist
+}
+
+func (v *value) AsList() *listType {
+	if v.valType != types.List {
+		panic(panicIncompatibleTypes)
+	}
+	return v.alist
 }
 
 // metric represents a single metric.

--- a/go/tricorder/metric.go
+++ b/go/tricorder/metric.go
@@ -525,7 +525,7 @@ type listType struct {
 	groupId   int
 	subType   types.Type
 	lock      sync.RWMutex
-	aslice    reflect.Value
+	aSlice    reflect.Value
 	timeStamp time.Time
 }
 
@@ -570,13 +570,13 @@ func convertFromIntOrUintSlice(
 	return defensiveCopy
 }
 
-// Returns aslice as a value and its type. If aSliceMutable is true,
-// always makes a defensive copy of aslice. If aSliceMutable is false,
-// may or may not make a defensive copy of aslice. If aslice is an []int
+// Returns aSlice as a value and its type. If sliceIsMutable is true,
+// always makes a defensive copy of aSlice. If sliceIsMutable is false,
+// may or may not make a defensive copy of aSlice. If aSlice is an []int
 // or []uint, returned value will be size specific, e.g []int64.
-func asSliceValue(aslice interface{}, aSliceMutable bool) (
+func asSliceValue(aSlice interface{}, sliceIsMutable bool) (
 	value reflect.Value, t types.Type) {
-	value = reflect.ValueOf(aslice)
+	value = reflect.ValueOf(aSlice)
 	if value.Kind() != reflect.Slice {
 		panic("Slice expected")
 	}
@@ -588,42 +588,42 @@ func asSliceValue(aslice interface{}, aSliceMutable bool) (
 	elemKind := elemType.Kind()
 	if elemKind == reflect.Int || elemKind == reflect.Uint {
 		value = convertFromIntOrUintSlice(value, t)
-	} else if aSliceMutable {
+	} else if sliceIsMutable {
 		value = copySlice(value)
 	}
 	return
 }
 
 func newListWithTimeStamp(
-	aslice interface{},
-	aSliceMutable bool,
+	aSlice interface{},
+	sliceIsMutable bool,
 	ts time.Time) *listType {
-	value, subType := asSliceValue(aslice, aSliceMutable)
+	value, subType := asSliceValue(aSlice, sliceIsMutable)
 	return &listType{
 		groupId:   <-idGenerator,
 		subType:   subType,
-		aslice:    value,
+		aSlice:    value,
 		timeStamp: ts}
 }
 
 func (l *listType) ChangeWithTimeStamp(
-	aslice interface{},
-	aSliceMutable bool,
+	aSlice interface{},
+	sliceIsMutable bool,
 	ts time.Time) {
-	value, subType := asSliceValue(aslice, aSliceMutable)
+	value, subType := asSliceValue(aSlice, sliceIsMutable)
 	if subType != l.subType {
 		panic("Sub-type in list cannot change.")
 	}
 	l.lock.Lock()
 	defer l.lock.Unlock()
-	l.aslice = value
+	l.aSlice = value
 	l.timeStamp = ts
 }
 
 func (l *listType) get() (value reflect.Value, ts time.Time) {
 	l.lock.RLock()
 	defer l.lock.RUnlock()
-	return l.aslice, l.timeStamp
+	return l.aSlice, l.timeStamp
 }
 
 func (l *listType) TextStrings(unit units.Unit) []string {

--- a/go/tricorder/metric_test.go
+++ b/go/tricorder/metric_test.go
@@ -1436,8 +1436,8 @@ func TestInt64List(t *testing.T) {
 		[]int64{2, 3, 5, 7},
 		ImmutableSlice,
 		kUsualTimeStamp)
-	aslice, ts := alist.AsSlice()
-	assertValueDeepEquals(t, []int64{2, 3, 5, 7}, aslice)
+	aSlice, ts := alist.AsSlice()
+	assertValueDeepEquals(t, []int64{2, 3, 5, 7}, aSlice)
 	assertValueEquals(t, kUsualTimeStamp, ts)
 	assertValueEquals(t, types.Int64, alist.SubType())
 
@@ -1451,9 +1451,9 @@ func TestInt64List(t *testing.T) {
 	mutableInt64Slice[1] = 12167
 	mutableInt64Slice[2] = 8192
 
-	aslice, ts = alist.AsSlice()
+	aSlice, ts = alist.AsSlice()
 	assertValueDeepEquals(
-		t, []int64{3000, 5000, 7000}, aslice)
+		t, []int64{3000, 5000, 7000}, aSlice)
 	assertValueEquals(t, kUsualTimeStamp.Add(5*time.Hour), ts)
 	textStrings := alist.TextStrings(units.None)
 	if assertValueEquals(t, 3, len(textStrings)) {
@@ -1480,8 +1480,8 @@ func TestBoolList(t *testing.T) {
 		[]bool{false, true, true},
 		ImmutableSlice,
 		kUsualTimeStamp)
-	aslice, ts := alist.AsSlice()
-	assertValueDeepEquals(t, []bool{false, true, true}, aslice)
+	aSlice, ts := alist.AsSlice()
+	assertValueDeepEquals(t, []bool{false, true, true}, aSlice)
 	assertValueEquals(t, kUsualTimeStamp, ts)
 	assertValueEquals(t, types.Bool, alist.SubType())
 	assertValueDeepEquals(
@@ -1499,9 +1499,9 @@ func TestDurationList(t *testing.T) {
 		[]time.Duration{time.Second, time.Minute},
 		ImmutableSlice,
 		kUsualTimeStamp)
-	aslice, ts := alist.AsSlice()
+	aSlice, ts := alist.AsSlice()
 	assertValueDeepEquals(
-		t, []time.Duration{time.Second, time.Minute}, aslice)
+		t, []time.Duration{time.Second, time.Minute}, aSlice)
 	assertValueEquals(t, kUsualTimeStamp, ts)
 	assertValueEquals(t, types.GoDuration, alist.SubType())
 	assertValueDeepEquals(
@@ -1537,13 +1537,13 @@ func TestTimeList(t *testing.T) {
 			kUsualTimeStamp.Add(3 * time.Hour)},
 		ImmutableSlice,
 		kUsualTimeStamp)
-	aslice, ts := alist.AsSlice()
+	aSlice, ts := alist.AsSlice()
 	assertValueDeepEquals(
 		t,
 		[]time.Time{
 			kUsualTimeStamp.Add(time.Hour),
 			kUsualTimeStamp.Add(3 * time.Hour)},
-		aslice)
+		aSlice)
 	assertValueEquals(t, kUsualTimeStamp, ts)
 	assertValueEquals(t, types.GoTime, alist.SubType())
 	assertValueDeepEquals(
@@ -1565,13 +1565,13 @@ func TestIntList(t *testing.T) {
 		[]int{-36, -49},
 		ImmutableSlice,
 		kUsualTimeStamp.Add(time.Hour))
-	aslice, ts := alist.AsSlice()
-	switch aslice.(type) {
+	aSlice, ts := alist.AsSlice()
+	switch aSlice.(type) {
 	case []int32:
-		assertValueDeepEquals(t, []int32{-36, -49}, aslice)
+		assertValueDeepEquals(t, []int32{-36, -49}, aSlice)
 		assertValueEquals(t, types.Int32, alist.SubType())
 	case []int64:
-		assertValueDeepEquals(t, []int64{-36, -49}, aslice)
+		assertValueDeepEquals(t, []int64{-36, -49}, aSlice)
 		assertValueEquals(t, types.Int64, alist.SubType())
 	default:
 		t.Fatal("Expected int32 or int64")
@@ -1581,13 +1581,13 @@ func TestIntList(t *testing.T) {
 		[]int{-100, -121, -144},
 		ImmutableSlice,
 		kUsualTimeStamp.Add(4*time.Hour))
-	aslice, ts = alist.AsSlice()
-	switch aslice.(type) {
+	aSlice, ts = alist.AsSlice()
+	switch aSlice.(type) {
 	case []int32:
-		assertValueDeepEquals(t, []int32{-100, -121, -144}, aslice)
+		assertValueDeepEquals(t, []int32{-100, -121, -144}, aSlice)
 		assertValueEquals(t, types.Int32, alist.SubType())
 	case []int64:
-		assertValueDeepEquals(t, []int64{-100, -121, -144}, aslice)
+		assertValueDeepEquals(t, []int64{-100, -121, -144}, aSlice)
 		assertValueEquals(t, types.Int64, alist.SubType())
 	default:
 		t.Fatal("Expected int32 or int64")
@@ -1612,13 +1612,13 @@ func TestUintList(t *testing.T) {
 		[]uint{89, 144, 233, 377, 610},
 		ImmutableSlice,
 		kUsualTimeStamp.Add(7*time.Hour))
-	aslice, ts := alist.AsSlice()
-	switch aslice.(type) {
+	aSlice, ts := alist.AsSlice()
+	switch aSlice.(type) {
 	case []uint32:
-		assertValueDeepEquals(t, []uint32{89, 144, 233, 377, 610}, aslice)
+		assertValueDeepEquals(t, []uint32{89, 144, 233, 377, 610}, aSlice)
 		assertValueEquals(t, types.Uint32, alist.SubType())
 	case []uint64:
-		assertValueDeepEquals(t, []uint64{89, 144, 233, 377, 610}, aslice)
+		assertValueDeepEquals(t, []uint64{89, 144, 233, 377, 610}, aSlice)
 		assertValueEquals(t, types.Uint64, alist.SubType())
 	default:
 		t.Fatal("Expected uint32 or uint64")

--- a/go/tricorder/types/api.go
+++ b/go/tricorder/types/api.go
@@ -10,29 +10,27 @@ import (
 type Type string
 
 const (
-	Unknown Type = ""
-	Bool    Type = "bool"
-	Int8    Type = "int8"
-	Int16   Type = "int16"
-	Int32   Type = "int32"
-	Int64   Type = "int64"
-	Uint8   Type = "uint8"
-	Uint16  Type = "uint16"
-	Uint32  Type = "uint32"
-	Uint64  Type = "uint64"
-	Float32 Type = "float32"
-	Float64 Type = "float64"
-	String  Type = "string"
-	Dist    Type = "distribution"
-	// for JSON RPC
-	Time Type = "time"
-	// for JSON RPC
-	Duration Type = "duration"
-
-	// for GoRPC
-	GoTime Type = "goTime"
-	// for GoRPC
+	Unknown    Type = ""
+	Bool       Type = "bool"
+	Int8       Type = "int8"
+	Int16      Type = "int16"
+	Int32      Type = "int32"
+	Int64      Type = "int64"
+	Uint8      Type = "uint8"
+	Uint16     Type = "uint16"
+	Uint32     Type = "uint32"
+	Uint64     Type = "uint64"
+	Float32    Type = "float32"
+	Float64    Type = "float64"
+	String     Type = "string"
+	GoTime     Type = "goTime"
 	GoDuration Type = "goDuration"
+	Dist       Type = "distribution"
+	List       Type = "list"
+	// for JSON RPC only
+	Time Type = "time"
+	// for JSON RPC only
+	Duration Type = "duration"
 )
 
 // FromGoValue returns the type of a value found in the GoRPC API.

--- a/go/tricorderclient/tricorderclient.go
+++ b/go/tricorderclient/tricorderclient.go
@@ -55,6 +55,14 @@ func main() {
 	} else {
 		printAsJson("/proc/foo/ddd metric", single)
 	}
+
+	err = client.Call("MetricsServer.GetMetric", "/list/squares", &single)
+	if err != nil {
+		log.Println("Got error for /list/squares:", err)
+	} else {
+		printAsJson("/list/squares metric", single)
+	}
+
 	time.Sleep(5 * time.Second)
 
 }


### PR DESCRIPTION
Here I explain the changes I did in metric.go

The List type in tricorder is designed the same way as CumulativeDistribution. List is an alias for private type "listType". The "List" type exposes only the public API for lists. The private type "listType" has several additional public methods for viewing lists that are not part of the public API but are used internally throughout the rest of tricorder to report values in a list.  These methods include
1. AsSlice() to get the raw list contents and timestamp
2. HtmlStrings() to get lists contents as a slice of strings for showing in html.
3. TextStrings() to get lists contents as a slice of strings for showing as raw text.

To promote reuse of code, I introduced several "valueToXXX" functions in metric.go that correspond to the existing "AsXXX" methods on tricorder.value instances. Just as the AsXXX methods pull data out of a tricorder.value instance in XXX format, the valueToXXX functions pull data out of a reflect.Value instance in XXX format. These new valueToXXX functions include.
1. valueToInterface
2. valueToTextString
3. valueToHtmlString

I then rewrote each AsXXX methods of tricorder.value to reuse its corresponding valueToXXX function. I also implemented the HtmlStrings(), TextStrings() tricorder.listType methods using valueToTextString and valueToHtmlString respectively. I reuse the valueToInterface function when the caller gives me an []int for a list and I need to store it as an []int32 or []int64.

The changes in the messages package are to handle the differences between how JSON and GoRPC render lists of times or lists of durations.
