### PR TITLE
Define unknown unit.

### DIFF
--- a/go/tricorder/messages/api.go
+++ b/go/tricorder/messages/api.go
@@ -102,7 +102,7 @@ type Metric struct {
 	// The description of this metric
 	Description string `json:"description"`
 	// The unit of measurement this metric represents
-	Unit units.Unit `json:"unit"`
+	Unit units.Unit `json:"unit,omitempty"`
 	// The metric's type
 	Kind types.Type `json:"kind"`
 	// The sub-type if type is an aggregate such as List.

--- a/go/tricorder/units/api.go
+++ b/go/tricorder/units/api.go
@@ -5,6 +5,7 @@ package units
 type Unit string
 
 const (
+	Unknown       Unit = ""
 	None          Unit = "None"
 	Millisecond   Unit = "Milliseconds"
 	Second        Unit = "Seconds"
@@ -12,6 +13,13 @@ const (
 	Byte          Unit = "Bytes"
 	BytePerSecond Unit = "BytesPerSecond"
 )
+
+func (u Unit) String() string {
+	if u == Unknown {
+		return "Unknown"
+	}
+	return string(u)
+}
 
 // Returns the conversion factor between seconds and u.
 // For example FromSeconds(Millisecond) returns 1000.

--- a/go/tricorderdemo/tricorderdemo.go
+++ b/go/tricorderdemo/tricorderdemo.go
@@ -38,7 +38,7 @@ func registerMetrics() {
 	if err := tricorder.RegisterMetric(
 		"/proc/rpc-count",
 		rpcCountCallback,
-		units.None,
+		units.Unknown,
 		"RPC count"); err != nil {
 		log.Fatalf("Got error %v registering metric", err)
 	}


### PR DESCRIPTION
units.Unit enumeration has always been a little weird because it does not include the zero value. Since in Go, zero values are typically ready to use values, the units.Unit should define the zero value.

Before, types.Type has no zero value, but I eventually defined types.Unknown as the zero value so that functions that return a type and an error could return a zero value for type that makes sense. 

I do the same in this PR for units.Unit, I define units.Unknown as the zero value. units.Unknown differs from units.None. units.None means no units. For instance, the total number of RPC calls an application makes has no units. units.Unknown on the other hand means that the units are unspecified. For example, a metric measuring distance where the units aren't known would have a unit of units.Unknown.

In this PR, I introduce units.Unknown and I make units be optional in the JSON. This should be ok as their are no known JSON clients yet. Scotty already handles zero values for units. This PR simply gives the zero value for units a name.
