### PR TITLE
Support parsing of JSON.

### DIFF
--- a/go/tricorder/duration/api.go
+++ b/go/tricorder/duration/api.go
@@ -28,6 +28,17 @@ func SinceEpochFloat(secondsSinceEpoch float64) Duration {
 	return sinceEpochFloat(secondsSinceEpoch)
 }
 
+// ParseWithUnit takes a string that is a quantity of unit and converts it
+// to a Duration.
+func ParseWithUnit(str string, unit units.Unit) (dur Duration, err error) {
+	inUnit, err := parse(str)
+	if err != nil {
+		return
+	}
+	dur = inUnit.convert(unit, units.Second)
+	return
+}
+
 // AsGoDuration converts this duration to a go duration
 func (d Duration) AsGoDuration() time.Duration {
 	return d.asGoDuration()
@@ -46,13 +57,13 @@ func (d Duration) AsFloat() float64 {
 
 // String shows in seconds
 func (d Duration) String() string {
-	return d.stringUsingUnits(units.Second)
+	return d.toString()
 }
 
 // StringUsingUnits shows in specified time unit.
 // If unit not a time, shows in seconds.
 func (d Duration) StringUsingUnits(unit units.Unit) string {
-	return d.stringUsingUnits(unit)
+	return d.convert(units.Second, unit).toString()
 }
 
 // IsNegative returns true if this duration is negative.

--- a/go/tricorder/duration/duration.go
+++ b/go/tricorder/duration/duration.go
@@ -47,11 +47,11 @@ func (d Duration) asGoTime() time.Time {
 }
 
 func (d Duration) toString() string {
-	formattedNs := d.Nanoseconds
-	if formattedNs < 0 {
-		formattedNs = -formattedNs
+	if d.isNegative() {
+		posd := d.mult(-1)
+		return fmt.Sprintf("-%d.%09d", posd.Seconds, posd.Nanoseconds)
 	}
-	return fmt.Sprintf("%d.%09d", d.Seconds, formattedNs)
+	return fmt.Sprintf("%d.%09d", d.Seconds, d.Nanoseconds)
 }
 
 func (d Duration) asFloat() float64 {

--- a/go/tricorder/duration/duration.go
+++ b/go/tricorder/duration/duration.go
@@ -1,14 +1,17 @@
 package duration
 
 import (
+	"errors"
 	"fmt"
 	"github.com/Symantec/tricorder/go/tricorder/units"
 	"math"
+	"strconv"
+	"strings"
 	"time"
 )
 
 const (
-	oneMillion = 1000000
+	oneBillion = 1000000000
 )
 
 func newDuration(d time.Duration) (result Duration) {
@@ -23,7 +26,7 @@ func sinceEpoch(t time.Time) (result Duration) {
 	result.Nanoseconds = int32(t.Nanosecond())
 	if result.Seconds < 0 && result.Nanoseconds > 0 {
 		result.Seconds++
-		result.Nanoseconds -= 1000000000 // 1 billion
+		result.Nanoseconds -= oneBillion
 	}
 	return
 }
@@ -43,22 +46,12 @@ func (d Duration) asGoTime() time.Time {
 	return time.Unix(d.Seconds, int64(d.Nanoseconds))
 }
 
-func (d Duration) stringUsingUnits(unit units.Unit) string {
+func (d Duration) toString() string {
 	formattedNs := d.Nanoseconds
 	if formattedNs < 0 {
 		formattedNs = -formattedNs
 	}
-	switch unit {
-	case units.Millisecond:
-		return fmt.Sprintf(
-			"%d%03d.%06d",
-			d.Seconds,
-			formattedNs/oneMillion,
-			formattedNs%oneMillion)
-	default: // second
-		return fmt.Sprintf("%d.%09d", d.Seconds, formattedNs)
-	}
-
+	return fmt.Sprintf("%d.%09d", d.Seconds, formattedNs)
 }
 
 func (d Duration) asFloat() float64 {
@@ -103,4 +96,72 @@ func (d Duration) prettyFormat() string {
 			d.Seconds%60)
 
 	}
+}
+
+func (d Duration) mult(scalar int64) (result Duration) {
+	fracprod := int64(d.Nanoseconds) * scalar
+	wholeprod := d.Seconds*scalar + fracprod/oneBillion
+	fracprod = fracprod % oneBillion
+	result.Seconds = wholeprod
+	result.Nanoseconds = int32(fracprod)
+	return
+}
+
+func (d Duration) div(scalar int64) (result Duration) {
+	wholequot := d.Seconds / scalar
+	wholerem := d.Seconds % scalar
+	fracquot := (int64(d.Nanoseconds) + wholerem*oneBillion) / scalar
+	result.Seconds = wholequot
+	result.Nanoseconds = int32(fracquot)
+	return
+}
+
+func (d Duration) convert(from, to units.Unit) Duration {
+	fromNum, fromDen := units.FromSecondsRational(from)
+	toNum, toDen := units.FromSecondsRational(to)
+	num := toNum * fromDen
+	den := toDen * fromNum
+	return d.mult(num).div(den)
+}
+
+func parse(str string) (result Duration, err error) {
+	var bNegative bool
+	if strings.HasPrefix(str, "-") {
+		bNegative = true
+		str = str[1:]
+	}
+	number := strings.SplitN(str, ".", 2)
+	whole, err := strconv.ParseInt(number[0], 10, 64)
+	if err != nil {
+		return
+	}
+	if whole < 0 {
+		err = errors.New("Double negative while parsing")
+		return
+	}
+	var frac uint64
+	if len(number) == 2 {
+		fracStr := number[1]
+		if len(fracStr) < 9 {
+			fracStr = fracStr + strings.Repeat("0", 9-len(fracStr))
+		} else {
+			fracStr = fracStr[:9]
+		}
+		frac, err = strconv.ParseUint(fracStr, 10, 32)
+		if err != nil {
+			return
+		}
+	}
+	if frac > 999999999 {
+		err = errors.New("Unexpected error")
+		return
+	}
+	if bNegative {
+		result.Seconds = -1 * whole
+		result.Nanoseconds = -1 * int32(frac)
+	} else {
+		result.Seconds = whole
+		result.Nanoseconds = int32(frac)
+	}
+	return
 }

--- a/go/tricorder/duration/duration_test.go
+++ b/go/tricorder/duration/duration_test.go
@@ -170,12 +170,12 @@ func TestString(t *testing.T) {
 	if out := dur.String(); out != "-53.200000000" {
 		t.Errorf("Expected -53.200000000, got %s", out)
 	}
-	if out := dur.StringUsingUnits(units.Millisecond); out != "-53200.000000" {
-		t.Errorf("Expected -53200.000000, got %s", out)
+	if out := dur.StringUsingUnits(units.Millisecond); out != "-53200.000000000" {
+		t.Errorf("Expected -53200.000000000, got %s", out)
 	}
 	dur = Duration{Seconds: 53, Nanoseconds: 123456789}
-	if out := dur.StringUsingUnits(units.Millisecond); out != "53123.456789" {
-		t.Errorf("Expected 53123.456789, got %s", out)
+	if out := dur.StringUsingUnits(units.Millisecond); out != "53123.456789000" {
+		t.Errorf("Expected 53123.456789000, got %s", out)
 	}
 }
 
@@ -216,6 +216,23 @@ func TestPrettyFormat(t *testing.T) {
 	assertStringEquals(t, "1d 0h 0m 0s", dur.PrettyFormat())
 	dur = Duration{Seconds: 200000}
 	assertStringEquals(t, "2d 7h 33m 20s", dur.PrettyFormat())
+}
+
+func TestParseWithUnit(t *testing.T) {
+	dur, err := ParseWithUnit("-4326.1601", units.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertStringEquals(t, "-4326.160100000", dur.String())
+	dur, err = ParseWithUnit("8078.211436", units.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertStringEquals(t, "8.078211436", dur.String())
+	_, err = ParseWithUnit("abcde", units.Second)
+	if err == nil {
+		t.Error("Expected error")
+	}
 }
 
 func assertStringEquals(t *testing.T, expected, actual string) {

--- a/go/tricorder/duration/duration_test.go
+++ b/go/tricorder/duration/duration_test.go
@@ -233,6 +233,21 @@ func TestParseWithUnit(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error")
 	}
+	dur, err = ParseWithUnit("793", units.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertStringEquals(t, "793.000000000", dur.String())
+	dur, err = ParseWithUnit("-8", units.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertStringEquals(t, "-0.008000000", dur.String())
+	dur, err = ParseWithUnit("0", units.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertStringEquals(t, "0.000000000", dur.String())
 }
 
 func assertStringEquals(t *testing.T, expected, actual string) {

--- a/go/tricorder/messages/api.go
+++ b/go/tricorder/messages/api.go
@@ -124,6 +124,11 @@ type Metric struct {
 	GroupId int `json:"groupId"`
 }
 
+// ConvertToGoRPC changes this metric in place to be go rpc compatible.
+func (m *Metric) ConvertToGoRPC() error {
+	return m.convertToGoRPC()
+}
+
 // ConvertToJson changes this metric in place to be json compatible.
 func (m *Metric) ConvertToJson() {
 	m.convertToJson()
@@ -144,6 +149,17 @@ func AsJsonWithSubType(
 	value interface{}, kind, subType types.Type, unit units.Unit) (
 	jsonValue interface{}, jsonKind, jsonSubType types.Type) {
 	return asJson(value, kind, subType, unit)
+}
+
+// ZeroValue works like types.Type.SafeZeroValue, but unlike the types.Type
+// version, this method can also return zero values for types in this
+// package.
+func ZeroValue(t types.Type) (interface{}, error) {
+	if t == types.Dist {
+		return (*Distribution)(nil), nil
+	} else {
+		return t.SafeZeroValue()
+	}
 }
 
 func init() {

--- a/go/tricorder/messages/metric.go
+++ b/go/tricorder/messages/metric.go
@@ -1,6 +1,7 @@
 package messages
 
 import (
+	"fmt"
 	"github.com/Symantec/tricorder/go/tricorder/duration"
 	"github.com/Symantec/tricorder/go/tricorder/types"
 	"github.com/Symantec/tricorder/go/tricorder/units"
@@ -8,8 +9,91 @@ import (
 	"time"
 )
 
+func valueAsString(value interface{}) (valueStr string, err error) {
+	valueStr, ok := value.(string)
+	if !ok {
+		err = fmt.Errorf("Value '%v' not a string", value)
+	}
+	return
+}
+
+func valueAsStringSlice(value interface{}) (valueSlice []string, err error) {
+	valueSlice, ok := value.([]string)
+	if !ok {
+		err = fmt.Errorf("Value '%v' not a string slice", value)
+	}
+	return
+}
+
+func asGoRPC(value interface{}, kind, subType types.Type, unit units.Unit) (
+	goRPCValue interface{}, goRPCKind, goRPCSubType types.Type, err error) {
+	switch kind {
+	case types.Duration:
+		var valueStr string
+		if valueStr, err = valueAsString(value); err != nil {
+			return
+		}
+		goRPCValue, err = stringAsDuration(valueStr, unit)
+		if err != nil {
+			return
+		}
+		goRPCKind = types.GoDuration
+	case types.Time:
+		var valueStr string
+		if valueStr, err = valueAsString(value); err != nil {
+			return
+		}
+		goRPCValue, err = stringAsTime(valueStr, unit)
+		if err != nil {
+			return
+		}
+		goRPCKind = types.GoTime
+	case types.List:
+		switch subType {
+		case types.Duration:
+			var valueSlice []string
+			if valueSlice, err = valueAsStringSlice(value); err != nil {
+				return
+			}
+			goRPCDurations := make([]time.Duration, len(valueSlice))
+			for i := range goRPCDurations {
+				goRPCDurations[i], err = stringAsDuration(valueSlice[i], unit)
+				if err != nil {
+					return
+				}
+			}
+			goRPCSubType = types.GoDuration
+			goRPCValue = goRPCDurations
+		case types.Time:
+			var valueSlice []string
+			if valueSlice, err = valueAsStringSlice(value); err != nil {
+				return
+			}
+			goRPCTimes := make([]time.Time, len(valueSlice))
+			for i := range goRPCTimes {
+				goRPCTimes[i], err = stringAsTime(valueSlice[i], unit)
+				if err != nil {
+					return
+				}
+			}
+			goRPCSubType = types.GoTime
+			goRPCValue = goRPCTimes
+		default:
+			goRPCSubType = subType
+			goRPCValue = value
+		}
+		goRPCKind = types.List
+	default:
+		goRPCKind = kind
+		goRPCValue = value
+	}
+	return
+}
+
 func asJson(value interface{}, kind, subType types.Type, unit units.Unit) (
 	jsonValue interface{}, jsonKind, jsonSubType types.Type) {
+	// TODO: Could type assertions in here fail? If so, how do we
+	// recover?
 	switch kind {
 	case types.GoDuration:
 		jsonKind = types.Duration
@@ -54,11 +138,43 @@ func asJson(value interface{}, kind, subType types.Type, unit units.Unit) (
 
 func (m *Metric) convertToJson() {
 	m.Value, m.Kind, m.SubType = asJson(m.Value, m.Kind, m.SubType, m.Unit)
-	if m.TimeStamp == nil {
+	switch i := m.TimeStamp.(type) {
+	case nil:
 		m.TimeStamp = ""
-	} else {
-		m.TimeStamp = duration.SinceEpoch(m.TimeStamp.(time.Time)).String()
+	case time.Time:
+		m.TimeStamp = duration.SinceEpoch(i).String()
+	case string:
+		// Do nothing we are already in json format
+	default:
+		m.TimeStamp = fmt.Sprintf("%v", i)
 	}
+}
+
+func (m *Metric) convertToGoRPC() error {
+	v, k, s, err := asGoRPC(m.Value, m.Kind, m.SubType, m.Unit)
+	if err != nil {
+		return err
+	}
+	var newTimeStamp interface{}
+	switch i := m.TimeStamp.(type) {
+	case nil, time.Time:
+		// already in go rpc format
+		newTimeStamp = i
+	case string:
+		if i == "" {
+			newTimeStamp = nil
+		} else {
+			newTimeStamp, err = stringAsTime(i, units.Second)
+			if err != nil {
+				return err
+			}
+		}
+	default:
+		return fmt.Errorf("Unrecognised value in timestamp field: '%v'", i)
+	}
+	m.Value, m.Kind, m.SubType = v, k, s
+	m.TimeStamp = newTimeStamp
+	return nil
 }
 
 func timeAsString(gotime time.Time, unit units.Unit) string {
@@ -69,6 +185,26 @@ func timeAsString(gotime time.Time, unit units.Unit) string {
 	return dur.StringUsingUnits(unit)
 }
 
+func stringAsTime(timeStr string, unit units.Unit) (
+	result time.Time, err error) {
+	dur, err := duration.ParseWithUnit(timeStr, unit)
+	if err != nil {
+		return
+	}
+	result = dur.AsGoTime()
+	return
+}
+
 func durationAsString(godur time.Duration, unit units.Unit) string {
 	return duration.New(godur).StringUsingUnits(unit)
+}
+
+func stringAsDuration(durationStr string, unit units.Unit) (
+	result time.Duration, err error) {
+	dur, err := duration.ParseWithUnit(durationStr, unit)
+	if err != nil {
+		return
+	}
+	result = dur.AsGoDuration()
+	return
 }

--- a/go/tricorder/messages/metric_test.go
+++ b/go/tricorder/messages/metric_test.go
@@ -9,13 +9,14 @@ import (
 )
 
 var (
-	kUsualTime    = time.Date(2016, 7, 13, 20, 35, 0, 0, time.UTC)
-	kUsualTimeStr = "1468442100.000000000"
+	kUsualTime      = time.Date(2016, 7, 13, 20, 35, 0, 0, time.UTC)
+	kUsualTimeLocal = kUsualTime.Local()
+	kUsualTimeStr   = "1468442100.000000000"
 )
 
 func TestPlainNoTs(t *testing.T) {
 	// For now, the only fields that affect ConvertToJSON are
-	// Value, Kind, SubType, and Unit
+	// Value, Kind, SubType, TimeStamp, and Unit
 	metric := Metric{
 		Value: int64(69),
 		Kind:  types.Int64,
@@ -53,7 +54,7 @@ func TestDurationMillis(t *testing.T) {
 	}
 	metric.ConvertToJson()
 	expected := Metric{
-		Value:     "960357.000000",
+		Value:     "960357.000000000",
 		Kind:      types.Duration,
 		Unit:      units.Millisecond,
 		TimeStamp: kUsualTimeStr,
@@ -88,7 +89,7 @@ func TestTimeMillis(t *testing.T) {
 	}
 	metric.ConvertToJson()
 	expected := Metric{
-		Value:     "1468442116924.000000",
+		Value:     "1468442116924.000000000",
 		Kind:      types.Time,
 		Unit:      units.Millisecond,
 		TimeStamp: kUsualTimeStr,
@@ -166,6 +167,225 @@ func TestTimeSlice(t *testing.T) {
 		Unit:      units.Second,
 		SubType:   types.Time,
 		TimeStamp: kUsualTimeStr,
+	}
+	assertDeepEquals(t, expected, metric)
+}
+
+func TestFromJSonPlainNoTs(t *testing.T) {
+	// For now, the only fields that affect ConvertToGoRPC are
+	// Value, Kind, SubType, TimeStamp, and Unit
+	metric := Metric{
+		Value:     int64(69),
+		Kind:      types.Int64,
+		TimeStamp: "",
+	}
+	if err := metric.ConvertToGoRPC(); err != nil {
+		t.Fatal(err)
+	}
+	expected := Metric{
+		Value: int64(69),
+		Kind:  types.Int64,
+	}
+	assertValueEquals(t, expected, metric)
+	// Test idempotence
+	if err := metric.ConvertToGoRPC(); err != nil {
+		t.Fatal(err)
+	}
+	assertValueEquals(t, expected, metric)
+}
+
+func TestFromJSONPlainTs(t *testing.T) {
+	metric := Metric{
+		Value:     int64(69),
+		Kind:      types.Int64,
+		TimeStamp: kUsualTimeStr,
+	}
+	if err := metric.ConvertToGoRPC(); err != nil {
+		t.Fatal(err)
+	}
+	expected := Metric{
+		Value:     int64(69),
+		Kind:      types.Int64,
+		TimeStamp: kUsualTimeLocal,
+	}
+	assertValueEquals(t, expected, metric)
+	// Test idempotence
+	if err := metric.ConvertToGoRPC(); err != nil {
+		t.Fatal(err)
+	}
+	assertValueEquals(t, expected, metric)
+}
+
+func TestFromJSONDurationMillis(t *testing.T) {
+	metric := Metric{
+		Value:     "960357.000000",
+		Kind:      types.Duration,
+		Unit:      units.Millisecond,
+		TimeStamp: kUsualTimeStr,
+	}
+	if err := metric.ConvertToGoRPC(); err != nil {
+		t.Fatal(err)
+	}
+	expected := Metric{
+		Value:     16*time.Minute + 357*time.Millisecond,
+		Kind:      types.GoDuration,
+		Unit:      units.Millisecond,
+		TimeStamp: kUsualTimeLocal,
+	}
+	assertValueEquals(t, expected, metric)
+	// Test idempotence
+	if err := metric.ConvertToGoRPC(); err != nil {
+		t.Fatal(err)
+	}
+	assertValueEquals(t, expected, metric)
+}
+
+func TestFromJSONDuration(t *testing.T) {
+	metric := Metric{
+		Value:     "960.357000000",
+		Kind:      types.Duration,
+		Unit:      units.Second,
+		TimeStamp: kUsualTimeStr,
+	}
+	if err := metric.ConvertToGoRPC(); err != nil {
+		t.Fatal(err)
+	}
+	expected := Metric{
+		Value:     16*time.Minute + 357*time.Millisecond,
+		Kind:      types.GoDuration,
+		Unit:      units.Second,
+		TimeStamp: kUsualTimeLocal,
+	}
+	assertValueEquals(t, expected, metric)
+	// Test idempotence
+	if err := metric.ConvertToGoRPC(); err != nil {
+		t.Fatal(err)
+	}
+	assertValueEquals(t, expected, metric)
+}
+
+func TestFromJSONTimeMillis(t *testing.T) {
+	metric := Metric{
+		Value:     "1468442116924.000000",
+		Kind:      types.Time,
+		Unit:      units.Millisecond,
+		TimeStamp: kUsualTimeStr,
+	}
+	if err := metric.ConvertToGoRPC(); err != nil {
+		t.Fatal(err)
+	}
+	expected := Metric{
+		Value: kUsualTimeLocal.Add(
+			16*time.Second + 924*time.Millisecond),
+		Kind:      types.GoTime,
+		Unit:      units.Millisecond,
+		TimeStamp: kUsualTimeLocal,
+	}
+	assertValueEquals(t, expected, metric)
+	// Test idempotence
+	if err := metric.ConvertToGoRPC(); err != nil {
+		t.Fatal(err)
+	}
+	assertValueEquals(t, expected, metric)
+}
+
+func TestFromJSONTimeSeconds(t *testing.T) {
+	metric := Metric{
+		Value:     "1468442116.924000000",
+		Kind:      types.Time,
+		Unit:      units.Second,
+		TimeStamp: kUsualTimeStr,
+	}
+	if err := metric.ConvertToGoRPC(); err != nil {
+		t.Fatal(err)
+	}
+	expected := Metric{
+		Value: kUsualTimeLocal.Add(
+			16*time.Second + 924*time.Millisecond),
+		Kind:      types.GoTime,
+		Unit:      units.Second,
+		TimeStamp: kUsualTimeLocal,
+	}
+	assertValueEquals(t, expected, metric)
+	// Test idempotence
+	if err := metric.ConvertToGoRPC(); err != nil {
+		t.Fatal(err)
+	}
+	assertValueEquals(t, expected, metric)
+}
+
+func TestFromJSONNilSlice(t *testing.T) {
+	metric := Metric{
+		Value:     []int32{},
+		Kind:      types.List,
+		SubType:   types.Int32,
+		TimeStamp: kUsualTimeStr,
+	}
+	if err := metric.ConvertToGoRPC(); err != nil {
+		t.Fatal(err)
+	}
+	expected := Metric{
+		Value:     []int32{},
+		Kind:      types.List,
+		SubType:   types.Int32,
+		TimeStamp: kUsualTimeLocal,
+	}
+	assertDeepEquals(t, expected, metric)
+	// Test idempotence
+	if err := metric.ConvertToGoRPC(); err != nil {
+		t.Fatal(err)
+	}
+	assertDeepEquals(t, expected, metric)
+}
+
+func TestFromJSONDurationSlice(t *testing.T) {
+	metric := Metric{
+		Value:     []string{"0.631000000"},
+		Kind:      types.List,
+		Unit:      units.Second,
+		SubType:   types.Duration,
+		TimeStamp: kUsualTimeStr,
+	}
+	if err := metric.ConvertToGoRPC(); err != nil {
+		t.Fatal(err)
+	}
+	expected := Metric{
+		Value:     []time.Duration{631 * time.Millisecond},
+		Kind:      types.List,
+		Unit:      units.Second,
+		SubType:   types.GoDuration,
+		TimeStamp: kUsualTimeLocal,
+	}
+	assertDeepEquals(t, expected, metric)
+	// Test idempotence
+	if err := metric.ConvertToGoRPC(); err != nil {
+		t.Fatal(err)
+	}
+	assertDeepEquals(t, expected, metric)
+}
+
+func TestFromJSONTimeSlice(t *testing.T) {
+	metric := Metric{
+		Value:     []string{"1468442100.453000000"},
+		Kind:      types.List,
+		Unit:      units.Second,
+		SubType:   types.Time,
+		TimeStamp: kUsualTimeStr,
+	}
+	if err := metric.ConvertToGoRPC(); err != nil {
+		t.Fatal(err)
+	}
+	expected := Metric{
+		Value:     []time.Time{kUsualTimeLocal.Add(453 * time.Millisecond)},
+		Kind:      types.List,
+		Unit:      units.Second,
+		SubType:   types.GoTime,
+		TimeStamp: kUsualTimeLocal,
+	}
+	assertDeepEquals(t, expected, metric)
+	// Test idempotence
+	if err := metric.ConvertToGoRPC(); err != nil {
+		t.Fatal(err)
 	}
 	assertDeepEquals(t, expected, metric)
 }

--- a/go/tricorder/metric_test.go
+++ b/go/tricorder/metric_test.go
@@ -828,7 +828,7 @@ func TestAPI(t *testing.T) {
 		t,
 		inMillisecondMetric, "/times/milliseconds",
 		"In milliseconds", units.Millisecond, types.Duration, 0,
-		"7008.000000")
+		"7008.000000000")
 	verifyRpcDefaultTsGroupId(
 		t,
 		inMillisecondMetric, "/times/milliseconds",
@@ -836,7 +836,7 @@ func TestAPI(t *testing.T) {
 		7*time.Second+8*time.Millisecond)
 
 	assertValueEquals(t, "7.008s", inMillisecondMetric.AsHtmlString(nil))
-	assertValueEquals(t, "7008.000000", inMillisecondMetric.AsTextString(nil))
+	assertValueEquals(t, "7008.000000000", inMillisecondMetric.AsTextString(nil))
 
 	// Check /proc/temperature
 	temperatureMetric := root.GetMetric("/proc/temperature")
@@ -1624,7 +1624,7 @@ func TestDurationList(t *testing.T) {
 	assertValueEquals(t, types.GoDuration, alist.SubType())
 	assertValueDeepEquals(
 		t,
-		[]string{"1000.000000", "60000.000000"},
+		[]string{"1000.000000000", "60000.000000000"},
 		alist.TextStrings(units.Millisecond))
 	assertValueDeepEquals(
 		t,

--- a/go/tricorder/types/api.go
+++ b/go/tricorder/types/api.go
@@ -2,6 +2,7 @@
 package types
 
 import (
+	"fmt"
 	"github.com/Symantec/tricorder/go/tricorder/duration"
 	"time"
 )
@@ -127,106 +128,100 @@ func FromGoValueWithSubType(value interface{}) (kind, subType Type) {
 	return
 }
 
+// SafeZeroValue is like ZeroValue except it returns an error instead of
+// panicing
+func (t Type) SafeZeroValue() (interface{}, error) {
+	switch t {
+	case Bool:
+		return false, nil
+	case Int8:
+		return int8(0), nil
+	case Int16:
+		return int16(0), nil
+	case Int32:
+		return int32(0), nil
+	case Int64:
+		return int64(0), nil
+	case Uint8:
+		return uint8(0), nil
+	case Uint16:
+		return uint16(0), nil
+	case Uint32:
+		return uint32(0), nil
+	case Uint64:
+		return uint64(0), nil
+	case Float32:
+		return float32(0), nil
+	case Float64:
+		return float64(0), nil
+	case String:
+		return "", nil
+	case Time, Duration:
+		return "0.000000000", nil
+	case GoTime:
+		return time.Time{}, nil
+	case GoDuration:
+		return time.Duration(0), nil
+	default:
+		return nil, fmt.Errorf("Cannot create zero value for type '%s'", t)
+	}
+}
+
 // ZeroValue returns the zero value for this type.
 // ZeroValue panics if this type is Dist, List, or Unknown.
 func (t Type) ZeroValue() interface{} {
+	result, err := t.SafeZeroValue()
+	if err != nil {
+		panic(err)
+	}
+	return result
+}
+
+// SafeNilSlice is like NilSlice except it returns an error instead of
+// panicing
+func (t Type) SafeNilSlice() (interface{}, error) {
 	switch t {
 	case Bool:
-		return false
+		return ([]bool)(nil), nil
 	case Int8:
-		return int8(0)
+		return ([]int8)(nil), nil
 	case Int16:
-		return int16(0)
+		return ([]int16)(nil), nil
 	case Int32:
-		return int32(0)
+		return ([]int32)(nil), nil
 	case Int64:
-		return int64(0)
+		return ([]int64)(nil), nil
 	case Uint8:
-		return uint8(0)
+		return ([]uint8)(nil), nil
 	case Uint16:
-		return uint16(0)
+		return ([]uint16)(nil), nil
 	case Uint32:
-		return uint32(0)
+		return ([]uint32)(nil), nil
 	case Uint64:
-		return uint64(0)
+		return ([]uint64)(nil), nil
 	case Float32:
-		return float32(0)
+		return ([]float32)(nil), nil
 	case Float64:
-		return float64(0)
-	case String:
-		return ""
-	case Dist:
-		panic("Dist type cannot create zero value")
-	case List:
-		panic("List type cannot create zero value")
-	case Time, Duration:
-		return "0.000000000"
+		return ([]float64)(nil), nil
+	case String, Time, Duration:
+		return ([]string)(nil), nil
 	case GoTime:
-		return time.Time{}
+		return ([]time.Time)(nil), nil
 	case GoDuration:
-		return time.Duration(0)
+		return ([]time.Duration)(nil), nil
 	default:
-		panic("Unknown type")
+		return nil, fmt.Errorf("Cannot create nil slice of type '%s'", t)
 	}
 }
 
 // NilSlice returns the nil slice of this type.
 // NilSlice panics if this type is Dist, List or Unknown.
 func (t Type) NilSlice() interface{} {
-	switch t {
-	case Bool:
-		var result []bool
-		return result
-	case Int8:
-		var result []int8
-		return result
-	case Int16:
-		var result []int16
-		return result
-	case Int32:
-		var result []int32
-		return result
-	case Int64:
-		var result []int64
-		return result
-	case Uint8:
-		var result []uint8
-		return result
-	case Uint16:
-		var result []uint16
-		return result
-	case Uint32:
-		var result []uint32
-		return result
-	case Uint64:
-		var result []uint64
-		return result
-	case Float32:
-		var result []float32
-		return result
-	case Float64:
-		var result []float64
-		return result
-	case String:
-		var result []string
-		return result
-	case Dist:
-		panic("Dist type cannot create nil slice")
-	case List:
-		panic("List type cannot create nil slice")
-	case Time, Duration:
-		var result []string
-		return result
-	case GoTime:
-		var result []time.Time
-		return result
-	case GoDuration:
-		var result []time.Duration
-		return result
-	default:
-		panic("Unknown type")
-
+	result, err := t.SafeNilSlice()
+	if err != nil {
+		panic(err)
 	}
+	return result
 }
 
 // CanToFromFloat returns true if this type supports conversion to/from float64

--- a/go/tricorder/units/api.go
+++ b/go/tricorder/units/api.go
@@ -25,10 +25,17 @@ func (u Unit) String() string {
 // For example FromSeconds(Millisecond) returns 1000.
 // Returns 1.0 if u is not a time unit.
 func FromSeconds(u Unit) float64 {
+	n, d := FromSecondsRational(u)
+	return float64(n) / float64(d)
+}
+
+// FromSecondsRational is the same as FromSeconds but returns answer as a
+// rational number.
+func FromSecondsRational(u Unit) (numerator, denominator int64) {
 	switch u {
 	case Millisecond:
-		return 1000.0
+		return 1000, 1
 	default:
-		return 1.0
+		return 1, 1
 	}
 }


### PR DESCRIPTION
These changes to tricorder allow scotty to parse JSON

Change highlights:
- duration.ParseWithUnit() to convert a time or duration expressed as "1234567890.987654321" into a go time or go duration
- tricorder/messages.Metric.ConvertToGoRPC() method to convert a JSON style metric struct into go rpc metric struct, which is what scotty understands.
- tricorder/messages.ZeroValue(types.Type) (interface{}, error)- Create a zero value of the specified type. Needed for converting a JSON value into the right go type
- tricorder/types.SafeZeroValue and tricorder/types.SafeNilSlice - Safe versions of ZeroValue and NilSlice that return errors instead of panicing in case "kind" field in JSON is unrecognized.
