### PR TITLE
Register array of times and durations with gob encoder.

### DIFF
--- a/go/tricorder/messages/api.go
+++ b/go/tricorder/messages/api.go
@@ -165,8 +165,12 @@ func ZeroValue(t types.Type) (interface{}, error) {
 func init() {
 	var tm time.Time
 	var dur time.Duration
+	var tml []time.Time
+	var durl []time.Duration
 	var dist *Distribution
 	gob.Register(tm)
 	gob.Register(dur)
+	gob.Register(tml)
+	gob.Register(durl)
 	gob.Register(dist)
 }


### PR DESCRIPTION
This has been broken for many months. We just never noticed because we don't have any list metrics yet. Without this change, go rpc will fail if an endpoint ever reports a list of times or list of durations metric.
