### PR TITLE
When unit is None, format ints and uints normally.

### DIFF
--- a/go/tricorder/metric.go
+++ b/go/tricorder/metric.go
@@ -1270,6 +1270,8 @@ func valueToHtmlString(
 		case units.BytePerSecond:
 			return iCompactForm(
 				value.Int(), 1024, bytePerSecondSuffixes)
+		case units.None:
+			return valueToTextString(value, t, u, isValueAPointer)
 		default:
 			return iCompactForm(
 				value.Int(), 1000, suffixes)
@@ -1282,6 +1284,8 @@ func valueToHtmlString(
 		case units.BytePerSecond:
 			return uCompactForm(
 				value.Uint(), 1024, bytePerSecondSuffixes)
+		case units.None:
+			return valueToTextString(value, t, u, isValueAPointer)
 		default:
 			return uCompactForm(
 				value.Uint(), 1000, suffixes)

--- a/go/tricorder/metric_test.go
+++ b/go/tricorder/metric_test.go
@@ -1579,11 +1579,17 @@ func TestInt64List(t *testing.T) {
 		assertValueEquals(t, "5000", textStrings[1])
 		assertValueEquals(t, "7000", textStrings[2])
 	}
-	htmlStrings := alist.HtmlStrings(units.None)
+	htmlStrings := alist.HtmlStrings(units.Celsius)
 	if assertValueEquals(t, 3, len(htmlStrings)) {
 		assertValueEquals(t, "3.00 thousand", htmlStrings[0])
 		assertValueEquals(t, "5.00 thousand", htmlStrings[1])
 		assertValueEquals(t, "7.00 thousand", htmlStrings[2])
+	}
+	htmlStrings = alist.HtmlStrings(units.None)
+	if assertValueEquals(t, 3, len(htmlStrings)) {
+		assertValueEquals(t, "3000", htmlStrings[0])
+		assertValueEquals(t, "5000", htmlStrings[1])
+		assertValueEquals(t, "7000", htmlStrings[2])
 	}
 	htmlStrings = alist.HtmlStrings(units.Byte)
 	if assertValueEquals(t, 3, len(htmlStrings)) {


### PR DESCRIPTION
No compact formats for ints and uints when unit is None.