### PR TITLE
Using an unregistered directory spec should not panic.

### DIFF
--- a/go/tricorder/api.go
+++ b/go/tricorder/api.go
@@ -378,8 +378,8 @@ func (d *DirectorySpec) UnregisterPath(path string) {
 // all metrics and directories within it. The caller can unregister any
 // DirectorySpec instance except the one representing the top level directory.
 // That DirectorySpec instance simply ignores calls to UnregisterDirectory.
-// Using an unregistered DirectorySpec instance to register new metrics may
-// cause a panic.
+// Metrics registered with an unregistered DirectorySpec instance will not
+// be reported.
 func (d *DirectorySpec) UnregisterDirectory() {
 	(*directory)(d).unregisterDirectory()
 }

--- a/go/tricorder/metric_test.go
+++ b/go/tricorder/metric_test.go
@@ -1225,33 +1225,6 @@ func TestAPI(t *testing.T) {
 		"temperature",
 		"test-start-time")
 
-	// Regisering metrics using fooDir should cause panic
-	func() {
-		defer func() {
-			if recover() != panicDirectoryUnregistered {
-				t.Error("Expected registring a metric on unregistered directory to panic.")
-			}
-		}()
-		fooDir.RegisterMetric("/should/not/work",
-			&anIntValue,
-			units.None,
-			"some metric")
-
-	}()
-
-	func() {
-		defer func() {
-			if recover() != panicDirectoryUnregistered {
-				t.Error("Expected registring a short metric on unregistered directory to panic.")
-			}
-		}()
-		fooDir.RegisterMetric("/wontwork",
-			&anIntValue,
-			units.None,
-			"some metric")
-
-	}()
-
 	if err := RegisterMetric(
 		"/proc/foo/bar/baz",
 		&anIntValue,


### PR DESCRIPTION
Panicing if developer unregisters a directory and subsequently tries to
use it seems like a good idea because that would catch a developer error.
However, in applications that concurrently register and unregister metrics,
this feature can cause panics during normal operation. For instance, one
goroutine creating a directory at "/foo" and registering metrics on it
while at the same time another goroutine unregisters the "/foo" path
could cause such a panic. Although this use case seems contrived, it can
happen in the scotty application.