### PR TITLE
Introduce tricorder.ReadMyMetrics

### DIFF
--- a/go/tricorder/api.go
+++ b/go/tricorder/api.go
@@ -2,6 +2,7 @@ package tricorder
 
 import (
 	"errors"
+	"github.com/Symantec/tricorder/go/tricorder/messages"
 	"github.com/Symantec/tricorder/go/tricorder/units"
 	"time"
 )
@@ -77,6 +78,13 @@ func (g *Group) RegisterMetric(
 	description string) error {
 	return root.registerMetric(
 		newPathSpec(path), metric, (*region)(g), unit, description)
+}
+
+// ReadMyMetrics reads all the current tricorder metrics in this process
+// at or under path. If no metrics found under path, ReadMyMetrics returns
+// an empty slice
+func ReadMyMetrics(path string) messages.MetricList {
+	return readMyMetrics(path)
 }
 
 // RegisterMetric registers a single metric with the health system in the

--- a/go/tricorder/metric.go
+++ b/go/tricorder/metric.go
@@ -1831,3 +1831,11 @@ func sortListEntries(listEntries []*listEntry) []*listEntry {
 	sort.Sort(byName(listEntries))
 	return listEntries
 }
+
+func readMyMetrics(path string) (result messages.MetricList) {
+	// Always returns nil error since rpcMetricsCollector.Collect
+	// always returns nil
+	root.GetAllMetricsByPath(
+		path, (*rpcMetricsCollector)(&result), nil)
+	return
+}


### PR DESCRIPTION
This PR deviates slightly from the original API proposal. ReadMyMetrics just returns a messages.MetricList instead of (messages.MetricList, error). In case no metrics are found under given path, ReadMyMetrics returns an empty slice.