### PR TITLE
Subtract released memory from /proc/memory/total built-in metric.

### DIFF
--- a/go/tricorder/setup.go
+++ b/go/tricorder/setup.go
@@ -25,7 +25,9 @@ func initDefaultMetrics() {
 	memStatsGroup.RegisterUpdateFunc(func() time.Time {
 		var memStats runtime.MemStats
 		runtime.ReadMemStats(&memStats)
-		totalMemory = memStats.Sys - memStats.HeapReleased
+		if memStats.Sys >= memStats.HeapReleased {
+			totalMemory = memStats.Sys - memStats.HeapReleased
+		}
 		return time.Now()
 	})
 	RegisterMetricInGroup(

--- a/go/tricorder/setup.go
+++ b/go/tricorder/setup.go
@@ -20,18 +20,20 @@ func timeValToDuration(val *wrapper.Timeval) time.Duration {
 
 func initDefaultMetrics() {
 	programArgs := getProgramArgs()
-	var memStats runtime.MemStats
+	var totalMemory uint64
 	memStatsGroup := NewGroup()
 	memStatsGroup.RegisterUpdateFunc(func() time.Time {
+		var memStats runtime.MemStats
 		runtime.ReadMemStats(&memStats)
+		totalMemory = memStats.Sys - memStats.HeapReleased
 		return time.Now()
 	})
 	RegisterMetricInGroup(
 		"/proc/memory/total",
-		&memStats.Sys,
+		&totalMemory,
 		memStatsGroup,
 		units.Byte,
-		"Memory system has allocated to process")
+		"System memory currently allocated to process")
 	var numGoroutines int
 	var resourceUsage wrapper.Rusage
 	var userTime time.Duration


### PR DESCRIPTION
runtime.MemStats.Sys contains the total virtual address space used by the
process. It does not represent the amount of physical memory used by the
process. System memory that was allocated and later released is included in
this value, which is not intuitive. This should probably have been called
/proc/memory/virtual.

By subtracting runtime.MemStats.HeapReleased (which contains the amount of
physical memory released to the OS), we get a much better approximation of
system (physical) memory currently used.