### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/go/tricorder/api.go
+++ b/go/tricorder/api.go
@@ -407,7 +407,7 @@ func (d *DirectorySpec) RegisterDirectory(
 	return (*DirectorySpec)(r), e
 }
 
-// Returns the absolute path this object represents
+// AbsPath returns the absolute path this object represents
 func (d *DirectorySpec) AbsPath() string {
 	return (*directory)(d).AbsPath()
 }

--- a/go/tricorder/metric.go
+++ b/go/tricorder/metric.go
@@ -960,7 +960,7 @@ func (v *value) evaluate(s *session) reflect.Value {
 	return result
 }
 
-// AsXXX methods return this value as a type XX.
+// AsBool methods return this value as a type XX.
 // AsXXX methods panic if this value is not of type XX.
 // If the caller passes a nil session to an AsXXX method,
 // it creates its own session internally.
@@ -1397,7 +1397,7 @@ func (m *metric) UpdateJsonMetric(s *session, metric *messages.Metric) {
 	m.InitJsonMetric(s, metric)
 }
 
-// InitJsonMetric initializes 'metric' for GoRPC with this instance
+// InitRpcMetric initializes 'metric' for GoRPC with this instance
 func (m *metric) InitRpcMetric(s *session, metric *messages.Metric) {
 	*metric = messages.Metric{
 		Path: m.AbsPath(), Description: m.Description}
@@ -1550,7 +1550,7 @@ func (d *directory) GetDirectoryOrMetric(relativePath string) (
 	return d.getDirectoryOrMetric(newPathSpec(relativePath))
 }
 
-// GetAllMetricsByPath does a depth first traversal of this directory to
+// GetAllMetrics does a depth first traversal of this directory to
 // find all the metrics and store them within collector.
 // If the Collect() method of collector returns a non nil error,
 // GetAllMetrics stops traversal and returns that same error.

--- a/go/tricorder/units/api.go
+++ b/go/tricorder/units/api.go
@@ -21,7 +21,7 @@ func (u Unit) String() string {
 	return string(u)
 }
 
-// Returns the conversion factor between seconds and u.
+// FromSeconds returns the conversion factor between seconds and u.
 // For example FromSeconds(Millisecond) returns 1000.
 // Returns 1.0 if u is not a time unit.
 func FromSeconds(u Unit) float64 {


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?